### PR TITLE
fix(giscus): load web component script and use HTML comment syntax

### DIFF
--- a/src/components/comment/Giscus.astro
+++ b/src/components/comment/Giscus.astro
@@ -8,10 +8,12 @@ if (!commentConfig || !commentConfig.giscus) {
 const giscus = commentConfig.giscus
 ---
 
-/**
- * Giscus 官方Web Component用法，兼容Astro静态输出，无需import包，无需NPM依赖！
- * 参考：https://giscus.app/ 详情配置说明
- */
+<script type="module" src="https://esm.sh/giscus"></script>
+
+<!-- 
+  Giscus 官方Web Component用法，兼容Astro静态输出，无需import包，无需NPM依赖！
+  参考：https://giscus.app/ 详情配置说明
+-->
 <giscus-widget
   id="comments"
   repo={giscus.repo}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

- The `<giscus-widget>` Web Component was not rendering because its definition script was missing.
- The `/** ... */` comment style was being rendered as plain text in the HTML output, causing unwanted display.

## Changes

- Added `<script type="module" src="https://esm.sh/giscus"></script>` to load the Web Component.
- Changed block comment from `/** ... */` to HTML-style `<!-- ... -->` to prevent literal display in the browser.

## Reference
- https://github.com/giscus/giscus-component
- https://giscus.app/