### PR TITLE
fix(markdown): apply text-align for table cells with align attribute

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -124,3 +124,18 @@
 .custom-md .expressive-code ol li::marker {
     @apply text-inherit;
 }
+
+/* 修复表格对齐问题 */
+.custom-md {  
+    table {  
+        th[align="left"], td[align="left"] {  
+            text-align: left;  
+        }  
+        th[align="center"], td[align="center"] {  
+            text-align: center;  
+        }  
+        th[align="right"], td[align="right"] {  
+            text-align: right;  
+        }  
+    }  
+}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

Currently, markdown tables using alignment syntax (e.g. `:---`, `:---:`, `---:`) generate `<th>` and `<td>` elements with `align="left|center|right"` attributes. However, the `.custom-md` styles do not respect these attributes, causing all table cells to remain left-aligned regardless of the markdown syntax.

## Changes

This PR adds CSS rules in `src/styles/markdown.css` to properly apply `text-align: left | center | right` based on the `align` attribute, restoring expected table alignment behavior.

Fixes table rendering issue in markdown content using `.custom-md` class.