### PR TITLE
feat(cover): 为所有封面图片显示加载指示器并添加配置开关

### DIFF
--- a/src/components/misc/RandomCoverImage.astro
+++ b/src/components/misc/RandomCoverImage.astro
@@ -125,8 +125,8 @@ const watermarkStyles = showWatermark ? getWatermarkStyles(watermark?.position) 
   'overflow-hidden relative',
   preview ? 'min-h-[150px] md:min-h-0' : 'min-h-[300px]'
 ]}> 
-  <!-- 加载指示器：只对随机图API显示 -->
-  {isRandomApiImage && (
+  <!-- 加载指示器：对所有文章封面图片显示 -->
+  {coverImageConfig.loadingIndicatorEnable !== false && (
     <div 
       class="image-loading-indicator absolute inset-0 flex items-center justify-center z-20 transition-opacity duration-300"
       style={`background-color: ${coverImageConfig.loading?.backgroundColor || '#fefefe'};`}
@@ -156,6 +156,35 @@ const watermarkStyles = showWatermark ? getWatermarkStyles(watermark?.position) 
       quality={preview ? 80 : 90}
       widths={preview ? [200, 400, 600] : [800, 1200, 1600, 2000]}
       sizes={preview ? "(max-width: 768px) 100vw, 28vw" : "(max-width: 768px) 100vw, (max-width: 1200px) 90vw, 1200px"}
+      onloadstart={`(function(img){
+        const container = img.parentElement;
+        if (container) {
+          const loadingIndicator = container.querySelector('.image-loading-indicator');
+          if (loadingIndicator) {
+            loadingIndicator.classList.remove('hidden');
+            loadingIndicator.style.removeProperty('opacity');
+            loadingIndicator.style.removeProperty('display');
+          }
+        }
+      })(this);`}
+      onload={`(function(img){
+        if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+          setTimeout(function() {
+            const container = img.parentElement;
+            if (container) {
+              const loadingIndicator = container.querySelector('.image-loading-indicator');
+              if (loadingIndicator) {
+                loadingIndicator.style.setProperty('opacity', '0', 'important');
+                loadingIndicator.style.setProperty('transition', 'opacity 0.3s ease-out', 'important');
+                setTimeout(function() {
+                  loadingIndicator.style.setProperty('display', 'none', 'important');
+                  loadingIndicator.classList.add('hidden');
+                }, 300);
+              }
+            }
+          }, 800);
+        }
+      })(this);`}
     />
   )}
   

--- a/src/config/coverImageConfig.ts
+++ b/src/config/coverImageConfig.ts
@@ -67,5 +67,7 @@ export const coverImageConfig: CoverImageConfig = {
     // 背景颜色
     backgroundColor: "rgba(0, 0, 0, 0.5)",
   },
+  // 加载指示器开关
+	loadingIndicatorEnable: true,
 };
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -293,6 +293,8 @@ export type CoverImageConfig = {
     color?: string; // 文字颜色，默认为白色
     backgroundColor?: string; // 背景颜色，默认为半透明黑色
   };
+  // 加载指示器开关
+	loadingIndicatorEnable: boolean;
 };
 
 // 组件配置类型定义


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

- src/components/misc/RandomCoverImage.astro：将加载指示器从仅针对随机图 API 改为针对所有文章封面图片显示。
- src/config/coverImageConfig.ts：新增 loadingIndicatorEnable 开关（默认 true）。
- src/types/config.ts：在 CoverImageConfig 类型中添加 loadingIndicatorEnable 属性。
- src/components/misc/RandomCoverImage.astro：根据 coverImageConfig.loadingIndicatorEnable 的值决定是否显示加载指示器。


## How To Test

- 在本地切换到该分支并启动开发环境
- 默认配置（/src/config/coverImageConfig/loadingIndicatorEnable = true）下打开任意文章，确认所有封面图片加载时显示加载指示器
- 修改配置为 loadingIndicatorEnable = false，重启/刷新，确认不再显示加载指示器
- 验证随机图 API 场景与普通封面场景都符合预期，并观察控制台无错误


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes
附上全局设置部分
```coverImageConfig.ts
export const coverImageConfig: CoverImageConfig = {
/* ...other config... */
	loadingIndicatorEnable: false,
    };
```

```types/config.ts
export type CoverImageConfig = {
/**/
  // 加载指示器开关
	loadingIndicatorEnable: boolean;
};
```
