### PR TITLE
fix: add .nojekyll to fix missing styles on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,9 @@ jobs:
       
       - name: Build site
         run: pnpm run build
+
+      - name: Create .nojekyll file
+        run: touch dist/.nojekyll
       
       - name: Deploy to pages branch
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/saicaca/fuwari/blob/main/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
N/A (Fixes deployment configuration)

## Changes

<!-- Please describe the changes you made in this pull request. -->
Added a step to create a `.nojekyll` file in the `dist` directory during the GitHub Actions workflow.

GitHub Pages uses Jekyll processing by default, which ignores directories starting with an underscore (like Astro's `_astro` folder). This caused CSS and JS assets to return 404 errors, resulting in a broken/unstyled site. The `.nojekyll` file disables this behavior.

## How To Test

<!-- Please describe how you tested your changes. -->
1. Trigger the "Deploy to Pages Branch" workflow.
2. Wait for the deployment to complete.
3. Visit the deployed GitHub Pages site.
4. Verify that the site loads correctly and styles are applied (assets in `_astro/` are now accessible).

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
N/A (Configuration change only)

## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
This is a standard fix for deploying Astro/Vite projects to GitHub Pages.