### PR TITLE
feat: 增加了自定义文章过期时间阈值

### DIFF
--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -61,7 +61,10 @@ export const siteConfig: SiteConfig = {
 
 	// 文章页底部的"上次编辑时间"卡片开关
 	showLastModified: true,
-
+	
+	// 文章过期阈值（天数），超过此天数才显示"上次编辑"卡片
+	outdatedThreshold: 30,
+	
 	// OpenGraph图片功能,注意开启后要渲染很长时间，不建议本地调试的时候开启
 	generateOgImages: false,
 

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -285,45 +285,51 @@ const jsonLd = {
 
   <!-- 上次编辑时间 -->
   {
-    siteConfig.showLastModified && (
-      <div class="card-base p-6 mb-4">
-        <div class="flex items-center gap-2">
-          <div class="transition h-9 w-9 rounded-lg overflow-hidden relative flex items-center justify-center mr-0">
-            <Icon
-              name="material-symbols:history-rounded"
-              class="text-4xl text-[var(--primary)] transition-transform group-hover:translate-x-0.5 bg-[var(--enter-btn-bg)] p-2 rounded-md"
-            />
-          </div>
+    siteConfig.showLastModified && (() => {
+      const lastModified = dayjs(
+        entry.data.updated || entry.data.published
+      );
+      const now = dayjs();
+      const daysDiff = now.diff(lastModified, "day");
+      // 使用用户定义的阈值，如果没有定义则默认为1天
+      const outdatedThreshold = siteConfig.outdatedThreshold ?? 1;
+      const shouldShowOutdatedCard = daysDiff >= outdatedThreshold;
 
-          {(() => {
-            const lastModified = dayjs(
-              entry.data.updated || entry.data.published
-            );
-            const now = dayjs();
-            const daysDiff = now.diff(lastModified, "day");
-            const dateStr = lastModified.format("YYYY-MM-DD");
-            const isOutdated = daysDiff >= 1;
+      return shouldShowOutdatedCard ? (
+        <div class="card-base p-6 mb-4">
+          <div class="flex items-center gap-2">
+            <div class="transition h-9 w-9 rounded-lg overflow-hidden relative flex items-center justify-center mr-0">
+              <Icon
+                name="material-symbols:history-rounded"
+                class="text-4xl text-[var(--primary)] transition-transform group-hover:translate-x-0.5 bg-[var(--enter-btn-bg)] p-2 rounded-md"
+              />
+            </div>
 
-            return (
-              <div class="flex flex-col gap-0.1">
-                <div class="text-[1.0rem] leading-tight text-black/75 dark:text-white/75">
-                  {`${i18n(I18nKey.lastModifiedPrefix)}${dateStr}${
-                    isOutdated
-                      ? `，${i18n(I18nKey.lastModifiedDaysAgo).replace("{days}", daysDiff.toString())}`
-                      : ""
-                  }`}
+            {(() => {
+              const dateStr = lastModified.format("YYYY-MM-DD");
+              const isOutdated = daysDiff >= 1;
+
+              return (
+                <div class="flex flex-col gap-0.1">
+                  <div class="text-[1.0rem] leading-tight text-black/75 dark:text-white/75">
+                    {`${i18n(I18nKey.lastModifiedPrefix)}${dateStr}${
+                      isOutdated
+                        ? `，${i18n(I18nKey.lastModifiedDaysAgo).replace("{days}", daysDiff.toString())}`
+                        : ""
+                    }`}
+                  </div>
+                  {isOutdated && (
+                    <p class="text-[0.8rem] leading-tight text-black/75 dark:text-white/75">
+                      {i18n(I18nKey.lastModifiedOutdated)}
+                    </p>
+                  )}
                 </div>
-                {isOutdated && (
-                  <p class="text-[0.8rem] leading-tight text-black/75 dark:text-white/75">
-                    {i18n(I18nKey.lastModifiedOutdated)}
-                  </p>
-                )}
-              </div>
-            );
-          })()}
+              );
+            })()}
+          </div>
         </div>
-      </div>
-    )
+      ) : null;
+    })()
   }
 
   <div

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -49,6 +49,7 @@ export type SiteConfig = {
 	navbarTitle?: string; // 导航栏标题，如果不设置则使用 title
 	navbarWidthFull?: boolean; // 导航栏是否占满屏幕宽度
 	showLastModified: boolean; // 控制"上次编辑"卡片显示的开关
+	outdatedThreshold?: number; // 文章过期阈值（天数），超过此天数才显示"上次编辑"卡片
 
 	// 页面开关配置
 	pages: {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes
- 增加了自定义文章过期时间的功能

## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

### 添加自定义文章过期阈值并未超过阈值天数：
<img width="847" height="436" alt="image" src="https://github.com/user-attachments/assets/c7f2fda9-0c24-4ff9-8a1c-fbf94a5b37a5" />

---

### 添加自定义文章过去阈值超过设定阈值天数：
<img width="858" height="426" alt="image" src="https://github.com/user-attachments/assets/322e79d9-7436-4faf-a416-66fc74cf90a5" />



## Additional Notes
 - 相关的设置添加在 `siteConfig` 中的 `outdatedThreshold,` 内，如果用户删除此条功能则默认为1天不会影响到正常的文章渲染
