### PR TITLE
style: Artalk 使用主题色

### DIFF
--- a/src/components/comment/Artalk.astro
+++ b/src/components/comment/Artalk.astro
@@ -18,7 +18,7 @@ const config = {
 <!-- Artalk -->
 <div class="relative w-full">
     <!-- 挂载点 -->
-    <div id="artalk"></div>
+    <div id="artalk" style="--at-color-main: var(--primary); --at-color-bg: var(--card-bg); --at-color-border: var(--line-divider);"></div>
 
     <!-- 引入 Artalk 样式 -->
     <link rel="stylesheet" href="https://unpkg.com/artalk/dist/Artalk.css"/>


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please describe): Artalk 使用主题色

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

优化 Artalk 组件的视觉一致性，使其自动适配站点主题色。

## Changes

<!-- Please describe the changes you made in this pull request. -->

- 使用 Artalk 支持的变量
- 适配暗色/亮色模式

## How To Test

<!-- Please describe how you tested your changes. -->

- 访问包含 Artalk 组件评论的页面
- 验证评论组件的主题色是否与站点主题色一致
- 切换暗色/亮色模式，确认 Artalk 样式正确适配

## Screenshots (if applicable)

修改前：
<img width="1039" height="747" alt="PixPin_2026-01-02_16-09-43" src="https://github.com/user-attachments/assets/ad4d593d-b0f9-4f16-8516-0170f3d627e9" />
<img width="1038" height="745" alt="PixPin_2026-01-02_16-08-02" src="https://github.com/user-attachments/assets/60180f8f-3ff1-45b5-beb3-b7c470b6e80a" />

修改后：
<img width="1050" height="759" alt="PixPin_2026-01-02_16-03-57" src="https://github.com/user-attachments/assets/6ce6e21e-200f-434d-990e-cd3e87f9d78d" />
<img width="1036" height="746" alt="PixPin_2026-01-02_16-04-46" src="https://github.com/user-attachments/assets/eba0de47-5ce6-48a1-bbd9-10259b0cc78f" />
<img width="1034" height="744" alt="PixPin_2026-01-02_16-14-40" src="https://github.com/user-attachments/assets/9f184086-b516-4e18-88e9-0d5214124ca6" />



## Additional Notes

如果不需要修改背景及边框可以移除 <code>--at-color-bg: var(--card-bg); --at-color-border: var(--line-divider);</code>
