### PR TITLE
refactor: 移除 Layout.astro 中的硬编码统计代码

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -89,37 +89,6 @@ const bannerOffset = `${BANNER_HEIGHT_EXTEND / 2}vh`;
 <!doctype html>
 <html lang={siteLang} class="bg-[var(--page-bg)] text-[14px] md:text-[16px]">
   <head>
-    <!-- Google Tag Manager -->
-    <script is:inline data-swup-ignore-script>
-      (function (w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "&l=" + l : "";
-        j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-        f.parentNode.insertBefore(j, f);
-      })(window, document, "script", "dataLayer", "GTM-P53R3M9S");
-    </script>
-    <!-- End Google Tag Manager -->
-    <!-- Microsoft Clarity -->
-    <script is:inline data-swup-ignore-script type="text/javascript">
-      (function (c, l, a, r, i, t, y) {
-        c[a] =
-          c[a] ||
-          function () {
-            (c[a].q = c[a].q || []).push(arguments);
-          };
-        t = l.createElement(r);
-        t.async = 1;
-        t.src = "https://www.clarity.ms/tag/" + i;
-        y = l.getElementsByTagName(r)[0];
-        y.parentNode.insertBefore(t, y);
-      })(window, document, "clarity", "script", "tx9equrgr6");
-    </script>
-    <!-- End Microsoft Clarity -->
-
     <title>{pageTitle}</title>
 
     <meta charset="UTF-8" />
@@ -443,13 +412,6 @@ const bannerOffset = `${BANNER_HEIGHT_EXTEND / 2}vh`;
         : []),
     ]}
   >
-    <noscript
-      ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-KRX3XGVH"
-        height="0"
-        width="0"
-        style="display:none;visibility:hidden"></iframe></noscript
-    >
 
     <!-- 页面顶部渐变高光效果 - 只在full和semifull模式下显示 -->
     {shouldShowTopHighlight && <div class="top-gradient-highlight" />}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe): 

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

N/A

## Changes

<!-- Please describe the changes you made in this pull request. -->

删除了  `src/layouts/Layout.astro`  文件中嵌入的第三方统计/分析脚本代码


## How To Test

- 执行 pnpm build 确认构建无报错
- 执行 pnpm preview 预览站点
- 检查浏览器开发者工具 Network 面板，确认无统计相关请求发出


## Screenshots (if applicable)
修改前：

<img width="981" height="258" alt="PixPin_2026-01-03_13-09-53" src="https://github.com/user-attachments/assets/70745647-4280-41c4-adb3-5a8e013b9399" />

修改后：

<img width="982" height="232" alt="PixPin_2026-01-03_13-13-17" src="https://github.com/user-attachments/assets/0ecf179f-7d92-48a4-9442-eb71ac163b3a" />



## Additional Notes

- 提交 `f456ab7` 中包含了统计代码
- 在该提交之后还有对统计代码部分的修改记录
- 无法确认统计代码是有意保留的功能特性，还是测试/示例代码
