### PR TITLE
fix: 优化点击外部关闭面板的逻辑，增加空值校验

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -567,18 +567,19 @@ function disableAnimation() {
   const bannerEnabled = !!document.getElementById("banner-wrapper");
 
   function setClickOutsideToClose(panel: string, ignores: string[]) {
-    document.addEventListener("click", (event) => {
-      let panelDom = document.getElementById(panel);
-      let tDom = event.target;
-      if (!(tDom instanceof Node)) return; // Ensure the event target is an HTML Node
-      for (let ig of ignores) {
-        let ie = document.getElementById(ig);
-        if (ie == tDom || ie?.contains(tDom)) {
-          return;
-        }
-      }
-      panelDom!.classList.add("float-panel-closed");
-    });
+      document.addEventListener("click", (event) => {
+          let panelDom = document.getElementById(panel);
+          if (!panelDom) return;
+          let tDom = event.target;
+          if (!(tDom instanceof Node)) return; // Ensure the event target is an HTML Node
+          for (let ig of ignores) {
+              let ie = document.getElementById(ig);
+              if (ie == tDom || ie?.contains(tDom)) {
+                  return;
+              }
+          }
+          panelDom.classList.add("float-panel-closed");
+      });
   }
   setClickOutsideToClose("display-setting", [
     "display-setting",


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
N/A

## Changes

<!-- Please describe the changes you made in this pull request. -->
为 setClickOutsideToClose 函数添加了针对 panelDom 的空值检查

## How To Test

<!-- Please describe how you tested your changes. -->
- 修改 `src/config/siteConfig.ts`，设置 `themeColor.fixed: true` 。
- 运行项目并打开浏览器控制台。
- 在页面任何位置点击，确认不再弹出 TypeError: Cannot read properties of null 的错误。

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
解决了由于配置文件（如 siteConfig.themeColor.fixed）导致某些 UI 面板未在 DOM 中渲染时，全局点击事件监听器可能引发的 JS 运行时错误。