### PR TITLE
fix: 移除代码块自定义选中背景色样式

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -93,9 +93,6 @@
 
     .expressive-code {
         @apply my-4;
-        ::selection {
-            @apply bg-[var(--codeblock-selection)];
-        }
     }
 
 

--- a/src/styles/variables-unified.styl
+++ b/src/styles/variables-unified.styl
@@ -42,7 +42,6 @@
   --inline-code-bg: var(--btn-regular-bg);
   --inline-code-color: var(--btn-content);
   --selection-bg: oklch(0.90 0.05 var(--hue));
-  --codeblock-selection: oklch(0.90 0.08 var(--hue));
   --codeblock-bg: oklch(0.17 0.015 var(--hue));
   --codeblock-topbar-bg: oklch(0.3 0.02 var(--hue));
   


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->

原来定义的值可读性不能兼顾亮色/暗色模式。

移除代码块自定义选中背景色样式，清理了冗余代码，代码块选中时将使用浏览器默认选中样式或全局 `--selection-bg` 变量。

- 删除 `markdown.css` 中`.expressive-code` 的 `::selection` 自定义样式
- 删除 `variables-unified.styl` 中未使用的 `--codeblock-selection` CSS 变量
## How To Test

<!-- Please describe how you tested your changes. -->
- 启动本地开发服务器
- 打开任意包含代码块的文章页面
- 选中代码块中的文本，确认选中效果正常显示

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
修改前亮色：
<img width="804" height="318" alt="PixPin_2026-01-05_16-57-46" src="https://github.com/user-attachments/assets/f6a412f4-087c-4e61-95f5-ffce03e45b35" />
<img width="770" height="329" alt="PixPin_2026-01-05_16-58-02" src="https://github.com/user-attachments/assets/651e29e0-dfc4-4775-8828-27a836d26efc" />
修改前暗色：
<img width="785" height="321" alt="PixPin_2026-01-05_16-58-48" src="https://github.com/user-attachments/assets/2676b62c-db05-4943-8ddc-e564676fdd85" />
<img width="797" height="331" alt="PixPin_2026-01-05_16-59-01" src="https://github.com/user-attachments/assets/c47b2fd2-7fb5-47ff-a3d9-d8705903a38b" />
修改后：
<img width="793" height="333" alt="PixPin_2026-01-05_16-56-54" src="https://github.com/user-attachments/assets/d0ee84b2-0b8f-4dc8-9615-ba9cfd03ca97" />
<img width="817" height="313" alt="PixPin_2026-01-05_16-57-05" src="https://github.com/user-attachments/assets/5953f364-2ffd-4d7c-978f-c56f69e93a84" />



## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
