### PR TITLE
feat: 添加 Google Analytics 和 Clarity 统计组件

### DIFF
--- a/src/components/analytics/Clarity.astro
+++ b/src/components/analytics/Clarity.astro
@@ -1,0 +1,15 @@
+---
+interface Props {
+	clarityId: string;
+}
+
+const { clarityId } = Astro.props;
+---
+
+<script is:inline data-swup-ignore-script define:vars={{ clarityId }}>
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", clarityId);
+</script>

--- a/src/components/analytics/GoogleAnalytics.astro
+++ b/src/components/analytics/GoogleAnalytics.astro
@@ -1,0 +1,19 @@
+---
+interface Props {
+	gaId: string;
+}
+
+const { gaId } = Astro.props;
+---
+
+<!-- Google tag (gtag.js) -->
+<script is:inline data-swup-ignore-script async src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}></script>
+<script is:inline data-swup-ignore-script define:vars={{gaId}}>window.dataLayer = window.dataLayer || [];
+
+function gtag() {
+    dataLayer.push(arguments);
+}
+
+gtag('js', new Date());
+gtag('config', gaId);
+</script>

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -129,6 +129,8 @@ export const siteConfig: SiteConfig = {
 
 	// 统计分析
 	analytics: {
+		// Google Analytics ID
+		gaId: "",
 		// Microsoft Clarity ID
 		clarityId: "tx9equrgr6",
 	},

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,6 @@
 ---
+import Clarity from "@components/analytics/Clarity.astro";
+import GoogleAnalytics from "@components/analytics/GoogleAnalytics.astro";
 import FancyboxManager from "@components/effects/FancyboxManager.astro";
 import KatexManager from "@components/effects/KatexManager.astro";
 import SakuraEffect from "@components/effects/SakuraEffect.astro";
@@ -94,31 +96,12 @@ const bannerOffset = `${BANNER_HEIGHT_EXTEND / 2}vh`;
 <!doctype html>
 <html lang={siteLang} class="bg-[var(--page-bg)] text-[14px] md:text-[16px]">
   <head>
-    <!-- Microsoft Clarity -->
-    {
-      siteConfig.analytics?.clarityId && (
-        <script
-          is:inline
-          data-swup-ignore-script
-          type="text/javascript"
-          define:vars={{ clarityId: siteConfig.analytics.clarityId }}
-        >
-          (function (c, l, a, r, i, t, y) {
-            c[a] =
-              c[a] ||
-              function () {
-                (c[a].q = c[a].q || []).push(arguments);
-              };
-            t = l.createElement(r);
-            t.async = 1;
-            t.src = "https://www.clarity.ms/tag/" + i;
-            y = l.getElementsByTagName(r)[0];
-            y.parentNode.insertBefore(t, y);
-          })(window, document, "clarity", "script", clarityId);
-        </script>
-      )
-    }
-    <!-- End Microsoft Clarity -->
+      {siteConfig.analytics?.gaId && (
+              <GoogleAnalytics gaId={siteConfig.analytics.gaId} />
+      )}
+      {siteConfig.analytics?.clarityId && (
+              <Clarity clarityId={siteConfig.analytics.clarityId} />
+      )}
 
     <title>{pageTitle}</title>
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -83,6 +83,7 @@ export type SiteConfig = {
 
 	// 统计分析
 	analytics?: {
+		gaId?: string; // Google Analytics ID
 		clarityId?: string; // Microsoft Clarity ID
 	};
 };


### PR DESCRIPTION


## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->
新增网站统计分析组件支持，包括：
- 新增 `GoogleAnalytics.astro` 组件，支持 Google Analytics 统计
- 新增 `Clarity.astro` 组件，支持 Microsoft Clarity 统计
- 在 `Layout.astro` 中集成统计组件，支持条件加载（配置为空时不加载）
- 在 `siteConfig.ts` 中添加 `analytics.gaId` 和 `analytics.clarityId` 配置项
- 更新 `types/config.ts` 类型定义
- 统计组件使用 `data-swup-ignore-script` 确保页面切换时脚本正常工作

## How To Test

<!-- Please describe how you tested your changes. -->
- 在 `src/config/siteConfig.ts` 中配置统计 ID：
   ```typescript
   analytics: {
       gaId: "G-XXXXXXXXXX",    // 填写您的 Google Analytics ID
       clarityId: "abcd1234",   // 填写您的 Microsoft Clarity ID
   }

- 启动开发服务器：pnpm dev

- 打开浏览器开发者工具 → Network 标签页，检查是否加载以下脚本：

https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX
https://www.clarity.ms/tag/abcd1234
- 测试条件加载：将 gaId 或 clarityId 设为空字符串 ""，确认对应脚本不加载


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->
- 两个统计组件均支持独立启用/禁用，互不影响
- 配置项留空时不会加载对应的统计脚本，不会影响页面性能


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
