### PR TITLE
fix: 添加备用 h1 标题解决 SwupA11yPlugin 检查警告

### DIFF
--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -408,6 +408,10 @@ const navbarWidthFull = siteConfig.navbar.widthFull ?? false;
             <main id="swup-container" class={`${mainContentClass} transition-main`}>
                 {/* 携带网格布局类名，用于JS更新父容器 */}
                 <div id="grid-class-carrier" data-grid-class={gridCols} class="hidden"></div>
+                {/* 备用 h1 标题 - 当主页横幅文本未启用时，提供隐藏的主标题 */}
+                {isHomePageCheck && !showHomeText && (
+                        <h1 class="sr-only">{siteConfig.title}</h1>
+                )}
                 <div id="content-wrapper" class="onload-animation transition-leaving">
                     <slot></slot>
                     <div class="footer col-span-2 onload-animation hidden lg:block">


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->
在 `MainGridLayout.astro`  添加了一个隐藏的备用 `<h1>` 标题元素。
- 使用 `sr-only` 类隐藏该标题
- 仅在首页且未显示横幅文本时渲染
- 标题内容为网站标题

## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
- 该修改不影响视觉呈现
- 条件渲染避免在不必要的情况下添加冗余元素