### PR TITLE
Fix typewriter effect to correctly handle emoji and Unicode characters

### DIFF
--- a/src/components/features/TypewriterText.astro
+++ b/src/components/features/TypewriterText.astro
@@ -85,15 +85,16 @@ const textData = Array.isArray(text) ? JSON.stringify(text) : text;
 
     private type() {
       const currentText = this.getCurrentText();
+      const segments = this.segmentText(currentText);
 
       if (this.isDeleting) {
         // 删除字符
         if (this.currentIndex > 0) {
           this.currentIndex--;
-          this.element.textContent = currentText.substring(
-            0,
-            this.currentIndex
-          );
+          this.element.textContent = segments
+            .slice(0, this.currentIndex)
+            .join("");
+
           this.timeoutId = window.setTimeout(
             () => this.type(),
             this.deleteSpeed
@@ -106,13 +107,12 @@ const textData = Array.isArray(text) ? JSON.stringify(text) : text;
           this.timeoutId = window.setTimeout(() => this.type(), this.speed);
         }
       } else {
-        // 添加字符
-        if (this.currentIndex < currentText.length) {
+        if (this.currentIndex < segments.length) {
           this.currentIndex++;
-          this.element.textContent = currentText.substring(
-            0,
-            this.currentIndex
-          );
+          this.element.textContent = segments
+            .slice(0, this.currentIndex)
+            .join("");
+
           this.timeoutId = window.setTimeout(() => this.type(), this.speed);
         } else {
           // 打字完成，暂停后开始删除（如果有多条文本）
@@ -133,6 +133,12 @@ const textData = Array.isArray(text) ? JSON.stringify(text) : text;
         clearTimeout(this.timeoutId);
       }
     }
+
+    private segmentText(text: string): string[] {
+      const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+      return Array.from(segmenter.segment(text), s => s.segment);
+    }
+
   }
 
   // 初始化所有打字机效果


### PR DESCRIPTION
Refactor typewriter effect to use text segments for typing and deleting characters.

## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Changes

- Refactored the typewriter effect to use text segments (grapheme clusters) instead of character indices.
- Ensured correct handling of emojis, combined characters, and other multi-codepoint Unicode symbols.
- Prevented visual glitches caused by partial deletion or rendering of emoji characters.
