### PR TITLE
fix: 修复 MusicPlayer 本地相对路径歌词（lrc）无法加载的问题

### DIFF
--- a/src/components/features/MusicPlayer.astro
+++ b/src/components/features/MusicPlayer.astro
@@ -27,7 +27,11 @@ const localPlaylist =
 							? song.cover
 							: url(song.cover)
 						: undefined,
-					lrc: song.lrc,
+					lrc: song.lrc
+						? isFullUrl(song.lrc)
+							? song.lrc
+							: url(song.lrc)
+						: undefined,
 				};
 			})
 		: [];
@@ -528,7 +532,11 @@ const widgetId =
         ui.lrcContainer.innerHTML = `<div class="text-neutral-400 text-sm py-10">${config.i18n.loadingLyrics}</div>`;
         
         if (track.lrc) {
-            if (track.lrc.startsWith('http')) {
+            const isLrcUrl = /^(https?:)?\/\//.test(track.lrc)
+                || track.lrc.startsWith('/')
+                || /\.(lrc|txt)(\?|#|$)/i.test(track.lrc);
+
+            if (isLrcUrl) {
                 fetch(track.lrc)
                     .then(res => res.text())
                     .then(text => renderLyrics(text))


### PR DESCRIPTION
## Type of change
- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue
N/A

## Changes
修复 `src/components/features/MusicPlayer.astro` 中本地歌词路径加载异常的问题。

之前只有 `track.lrc.startsWith('http')` 才会走 `fetch`，导致相对路径歌词（如 `/assets/music/test.lrc`）会被当成普通文本解析，从而无法正常显示。

修复后：对于 URL/相对路径特征的 `lrc` 值都会走 `fetch`，相对路径歌词可正常加载；不影响原有逻辑。

## How To Test
1. 在本地模式配置一首歌曲，`lrc` 使用相对路径（例如 `/assets/music/test.lrc`）。
2. 配置音乐组件并启动项目。
3. 确认歌词可正常加载并同步显示。
4. 回归验证：其他歌曲播放与歌词逻辑正常。

## Screenshots (if applicable)
N/A

