### PR TITLE
feat(config): 添加Bangumi条目类型排序功能

### DIFF
--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -113,6 +113,10 @@ export const siteConfig: SiteConfig = {
 	bangumi: {
 		// Bangumi用户ID
 		userId: "1143164",
+		// 条目类型排序，数组中的类型将按顺序优先展示
+		// 可选值: "anime" | "book" | "music" | "game" | "real" (暂不支持"real"类型)
+		// 未列出的类型将按默认顺序排在后面
+		categoryOrder: ["anime", "book", "music", "game"],
 	},
 
 	// 页面开关配置 - 控制特定页面的访问权限，设为false会返回404

--- a/src/pages/bangumi.astro
+++ b/src/pages/bangumi.astro
@@ -183,6 +183,24 @@ for (const [categoryKey, enabled] of Object.entries(bangumiConfig.categories)) {
 	}
 }
 
+// 根据 categoryOrder 配置对 tabs 进行排序
+const categoryOrder = siteConfig.bangumi?.categoryOrder || [];
+if (categoryOrder.length > 0) {
+	tabs.sort((a, b) => {
+		const aIndex = categoryOrder.indexOf(
+			a.id as (typeof categoryOrder)[number],
+		);
+		const bIndex = categoryOrder.indexOf(
+			b.id as (typeof categoryOrder)[number],
+		);
+		// 如果类型在配置中，按配置顺序排序；否则排在后面
+		if (aIndex === -1 && bIndex === -1) return 0;
+		if (aIndex === -1) return 1;
+		if (bIndex === -1) return -1;
+		return aIndex - bIndex;
+	});
+}
+
 const activeTab = tabs[0]?.id || "anime";
 ---
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -45,9 +45,10 @@ export type SiteConfig = {
 		theme: "github" | "obsidian" | "vitepress";
 	};
 
-	// 添加bangumi配置
+	// bangumi配置
 	bangumi?: {
 		userId?: string; // Bangumi用户ID
+		categoryOrder?: ("anime" | "game" | "book" | "music" | "real")[]; // 条目类型排序顺序
 	};
 
 	generateOgImages: boolean;


### PR DESCRIPTION
## Type of change
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist
- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue
无

## Changes
为番组计划页面添加条目类型排序功能：
- 在 `siteConfig.ts` 中新增 `bangumi.categoryOrder` 配置项
- 在 `config.ts` 中添加相应的类型定义
- 修改 `bangumi.astro` 页面，根据配置对 Tab 进行排序

## How To Test
1. 在 `src/config/siteConfig.ts` 中配置 `bangumi.categoryOrder`
2. 运行 `pnpm run dev` 启动开发服务器
3. 访问 `/bangumi` 页面，验证 Tab 顺序是否符合配置

## Screenshots (if applicable)
配置 `categoryOrder: ["anime", "game", "book", "music"]` 后，Tab 顺序为：动画 → 游戏 → 书籍 → 音乐

## Additional Notes
可选值：`"anime"` | `"game"` | `"book"` | `"music"` | `"real"`，未列出的类型将按默认顺序排在后面。