### PR TITLE
 feat(bangumi): 支持通过 hash 定位 Bangumi 分类

### DIFF
--- a/src/components/pages/bangumi/TabNav.astro
+++ b/src/components/pages/bangumi/TabNav.astro
@@ -65,34 +65,80 @@ const { tabs, activeTab } = Astro.props;
       });
     }
 
+    function activateTab(targetTab: string, shouldSyncHash = true) {
+      if (!targetTab) {
+        return;
+      }
+
+      const targetButton = Array.from(tabButtons).find(
+        (button) => (button as HTMLButtonElement).dataset.tab === targetTab
+      ) as HTMLButtonElement | undefined;
+
+      if (!targetButton) {
+        return;
+      }
+
+      // Update active tab
+      tabButtons.forEach(btn => {
+        btn.classList.remove('border-(--primary)', 'text-(--primary)');
+        btn.classList.add('border-transparent', 'text-gray-500', 'hover:text-gray-700', 'hover:border-gray-300', 'dark:text-gray-400', 'dark:hover:text-gray-300');
+      });
+
+      targetButton.classList.remove('border-transparent', 'text-gray-500', 'hover:text-gray-700', 'hover:border-gray-300', 'dark:text-gray-400', 'dark:hover:text-gray-300');
+      targetButton.classList.add('border-(--primary)', 'text-(--primary)');
+
+      // Show/hide sections
+      sections.forEach(section => {
+        const htmlSection = section as HTMLElement;
+        if (htmlSection.dataset.section === targetTab) {
+          htmlSection.classList.remove('hidden');
+        } else {
+          htmlSection.classList.add('hidden');
+        }
+      });
+
+      hydrateVisibleImages(targetTab);
+
+      if (shouldSyncHash) {
+        const nextHash = `#${encodeURIComponent(targetTab)}`;
+        if (window.location.hash !== nextHash) {
+          window.history.replaceState(null, '', nextHash);
+        }
+      }
+    }
+
+    function getTabFromHash() {
+      const hash = window.location.hash.replace(/^#/, '');
+      if (!hash) {
+        return '';
+      }
+      try {
+        return decodeURIComponent(hash);
+      } catch {
+        return '';
+      }
+    }
+
     tabButtons.forEach(button => {
       button.addEventListener('click', (event) => {
         const currentButton = event.currentTarget as HTMLButtonElement;
         const targetTab = currentButton.dataset.tab;
-
-        // Update active tab
-        tabButtons.forEach(btn => {
-          btn.classList.remove('border-(--primary)', 'text-(--primary)');
-          btn.classList.add('border-transparent', 'text-gray-500', 'hover:text-gray-700', 'hover:border-gray-300', 'dark:text-gray-400', 'dark:hover:text-gray-300');
-        });
-
-        currentButton.classList.remove('border-transparent', 'text-gray-500', 'hover:text-gray-700', 'hover:border-gray-300', 'dark:text-gray-400', 'dark:hover:text-gray-300');
-        currentButton.classList.add('border-(--primary)', 'text-(--primary)');
-
-        // Show/hide sections
-        sections.forEach(section => {
-          const htmlSection = section as HTMLElement;
-          if (htmlSection.dataset.section === targetTab) {
-            htmlSection.classList.remove('hidden');
-          } else {
-            htmlSection.classList.add('hidden');
-          }
-        });
-
         if (targetTab) {
-          hydrateVisibleImages(targetTab);
+          activateTab(targetTab, true);
         }
       });
+    });
+
+    const initialTab = getTabFromHash();
+    if (initialTab) {
+      activateTab(initialTab, false);
+    }
+
+    window.addEventListener('hashchange', () => {
+      const tabFromHash = getTabFromHash();
+      if (tabFromHash) {
+        activateTab(tabFromHash, false);
+      }
     });
   }
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.


## Related Issue

无

## Changes

- 在 Bangumi 页面切换 Tab（如 `game` / `anime`）时，同步将当前分类写入 URL hash（例如 `#game`）。
- 页面初始化时读取 URL hash，并自动切换到对应分类
- 监听 `hashchange`，支持通过修改 hash 在分类间切换
- 对非法 hash 解码增加容错

## How To Test

1. 打开 `/bangumi/`，点击不同分类，确认 URL hash 会随之变化（如 `#anime`、`#game`）
2. 直接访问带 hash 的链接（如 `/bangumi/#game`），确认页面默认定位到对应分类
3. 在已打开页面中手动修改 hash，确认分类同步切换且内容区显示正确

## Screenshots (if applicable)

无

## Additional Notes

我觉得总共就那几个Tab没必要每切换一条都写入历史记录吧（
所以是替换历史记录项而不是新增，浏览器前进/后退不会按 Tab 切换历史记录