### PR TITLE
feat: 优化分类导航渲染逻辑，仅在首页、首页分页和归档页进行服务端渲染

### DIFF
--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -27,7 +27,6 @@ import { i18n } from "@/i18n/translation";
 import { formatDateToYYYYMMDD } from "@/utils/date-utils";
 import { getImageQuality } from "@/utils/image-utils";
 import { getBackgroundImages, isHomePage } from "@/utils/layout-utils";
-import { url } from "@/utils/url-utils";
 import {
 	generateGridClasses,
 	generateMainContentClasses,
@@ -36,6 +35,7 @@ import {
 	getResponsiveSidebarConfig,
 	type ResponsiveSidebarConfig,
 } from "@/utils/responsive-utils";
+import { url } from "@/utils/url-utils";
 import Layout from "./Layout.astro";
 
 import "@/styles/markdown.css";

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -27,6 +27,7 @@ import { i18n } from "@/i18n/translation";
 import { formatDateToYYYYMMDD } from "@/utils/date-utils";
 import { getImageQuality } from "@/utils/image-utils";
 import { getBackgroundImages, isHomePage } from "@/utils/layout-utils";
+import { url } from "@/utils/url-utils";
 import {
 	generateGridClasses,
 	generateMainContentClasses,
@@ -125,6 +126,24 @@ const creditUrlMobile =
 
 // 检查是否为首页
 const isHomePageCheck = isHomePage(Astro.url.pathname);
+
+// 分类导航仅在首页、首页分页和归档页进行服务端渲染，避免非列表页首屏闪烁
+const currentPathname = Astro.url.pathname.replace(/\/$/, "");
+const homePath = url("/").replace(/\/$/, "");
+const archivePath = url("/archive/").replace(/\/$/, "");
+const escapedHomePath = homePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const isHomeRoute =
+	currentPathname === homePath ||
+	currentPathname === "" ||
+	currentPathname === "/";
+const isArchiveRoute = currentPathname === archivePath;
+const isHomePaginationRoute =
+	/^\/\d+$/.test(currentPathname) ||
+	(homePath !== "" &&
+		new RegExp(`^${escapedHomePath}\\/\\d+$`).test(currentPathname));
+const shouldRenderCategoryBar =
+	!!siteConfig.categoryBar &&
+	(isHomeRoute || isHomePaginationRoute || isArchiveRoute);
 
 // 检查是否在文章详情页
 const isPostPage = !!postSlug;
@@ -872,8 +891,8 @@ const bannerCarouselInterval = Math.max(
                     
             {/* 主内容区包装器 - 包含静态栏位和swup容器，作为单个grid item */}
             <div class={staticBarClass}>
-                {/* 分类导航栏 - 在所有页面渲染，由客户端JS控制显隐 */}
-                {siteConfig.categoryBar && <CategoryBar />}
+                {/* 分类导航栏 - 仅在首页、首页分页和归档页渲染 */}
+                {shouldRenderCategoryBar && <CategoryBar />}
 
                 {/* 主内容区 - 始终渲染，确保 Swup 容器存在 */}
                 <main id="swup-container" class="transition-main">


### PR DESCRIPTION
## Type of change

- [√] Bug fix (a non-breaking change that fixes an issue)

## Checklist

- [√ ] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [√ ] I have checked to ensure that this Pull Request is not for personal changes.
- [√ ] I have performed a self-review of my own code.
- [√ ] My changes generate no new warnings.

## Changes
修复了非文章列表页分类导航栏闪现的问题。
之前分类栏会在所有页面先被服务端渲染，再由客户端脚本在非目标页面隐藏，导致例如 /friends/ 这类页面出现“先显示后消失”的闪烁，改为在布局层进行服务端条件渲染：仅在首页、首页分页、归档页渲染分类导航栏；其余页面不输出该组件。
同时保留 siteConfig 中的分类栏总开关逻辑，开关行为不变。
<!-- Please describe the changes you made in this pull request. -->

## How To Test
启动项目并访问首页和分页（如 /2/）归档页（/archive/），确认分类导航栏正常显示。
访问非文章列表页（如 /friends/、/about/ 或其他自定义页面），确认不再出现分类栏闪烁。
<!-- Please describe how you tested your changes. -->

## Screenshots (if applicable)
可以去[我的博客](https://blog.teadrink.me/friends/)看一看效果
