### PR TITLE
feat(analytics): 为 Umami Analytics 添加出站点击追踪、性能、回放功能

### DIFF
--- a/src/components/analytics/UmamiAnalytics.astro
+++ b/src/components/analytics/UmamiAnalytics.astro
@@ -2,9 +2,10 @@
 interface Props {
 	websiteId: string;
 	scriptUrl?: string;
+	trackOutboundLinks?: boolean;
 }
 
-const { websiteId, scriptUrl } = Astro.props;
+const { websiteId, scriptUrl, trackOutboundLinks = true } = Astro.props;
 ---
 
 <script
@@ -14,3 +15,35 @@ const { websiteId, scriptUrl } = Astro.props;
 	src={scriptUrl}
 	data-website-id={websiteId}
 ></script>
+
+{
+	trackOutboundLinks && (
+		<script is:inline data-swup-ignore-script>
+			;(() => {
+				const name = 'outbound-link-click'
+
+				const applyOutboundTracking = () => {
+					document.querySelectorAll('a').forEach((a) => {
+						if (
+							a.host !== window.location.host &&
+							!a.getAttribute('data-umami-event')
+						) {
+							a.setAttribute('data-umami-event', name)
+							a.setAttribute('data-umami-event-url', a.href)
+						}
+					})
+				}
+
+				if (document.readyState === 'loading') {
+					document.addEventListener('DOMContentLoaded', applyOutboundTracking, {
+						once: true,
+					})
+				} else {
+					applyOutboundTracking()
+				}
+
+				document.addEventListener('astro:page-load', applyOutboundTracking)
+			})()
+		</script>
+	)
+}

--- a/src/components/analytics/UmamiAnalytics.astro
+++ b/src/components/analytics/UmamiAnalytics.astro
@@ -4,6 +4,13 @@ interface Props {
 	scriptUrl?: string;
 	trackOutboundLinks?: boolean;
 	collectWebVitals?: boolean;
+	relpays?: {
+		enabled?: boolean;
+		sampleRate?: number;
+		maskLevel?: "moderate" | "strict";
+		maxDuration?: number;
+		blockSelector?: string;
+	};
 }
 
 const {
@@ -11,7 +18,14 @@ const {
 	scriptUrl,
 	trackOutboundLinks = true,
 	collectWebVitals = false,
+	relpays,
 } = Astro.props;
+
+const relpaysEnabled = relpays?.enabled ?? false;
+const relpaysSampleRate = relpays?.sampleRate ?? 0.15;
+const relpaysMaskLevel = relpays?.maskLevel ?? "moderate";
+const relpaysMaxDuration = relpays?.maxDuration ?? 300000;
+const relpaysBlockSelector = relpays?.blockSelector?.trim();
 ---
 
 <script
@@ -21,6 +35,12 @@ const {
 	src={scriptUrl}
 	data-website-id={websiteId}
 	data-performance={collectWebVitals ? "true" : undefined}
+	data-sample-rate={relpaysEnabled ? String(relpaysSampleRate) : undefined}
+	data-mask-level={relpaysEnabled ? relpaysMaskLevel : undefined}
+	data-max-duration={relpaysEnabled ? String(relpaysMaxDuration) : undefined}
+	data-block-selector={
+		relpaysEnabled && relpaysBlockSelector ? relpaysBlockSelector : undefined
+	}
 ></script>
 
 {

--- a/src/components/analytics/UmamiAnalytics.astro
+++ b/src/components/analytics/UmamiAnalytics.astro
@@ -3,9 +3,15 @@ interface Props {
 	websiteId: string;
 	scriptUrl?: string;
 	trackOutboundLinks?: boolean;
+	collectWebVitals?: boolean;
 }
 
-const { websiteId, scriptUrl, trackOutboundLinks = true } = Astro.props;
+const {
+	websiteId,
+	scriptUrl,
+	trackOutboundLinks = true,
+	collectWebVitals = false,
+} = Astro.props;
 ---
 
 <script
@@ -14,6 +20,7 @@ const { websiteId, scriptUrl, trackOutboundLinks = true } = Astro.props;
 	defer
 	src={scriptUrl}
 	data-website-id={websiteId}
+	data-performance={collectWebVitals ? "true" : undefined}
 ></script>
 
 {

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -182,6 +182,8 @@ export const siteConfig: SiteConfig = {
 			websiteId: "",
 			// Umami JS地址，支持使用自建
 			scriptUrl: "https://cloud.umami.is/script.js",
+			// 是否追踪出站链接
+			trackOutboundLinks: true,
 		},
 		// 51la 统计配置
 		la51Analytics: {

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -186,6 +186,19 @@ export const siteConfig: SiteConfig = {
 			trackOutboundLinks: true,
 			// 是否收集浏览器性能指标
 			collectWebVitals: false,
+			// 会话回放配置
+			relpays: {
+				// 是否启用会话回放
+				enabled: false,
+				// 录制会话采样率，范围 0-1，例如 0.15 表示记录 15% 的会话
+				sampleRate: 0.15,
+				// 隐私遮罩级别："moderate" 会遮罩所有输入框；"strict" 额外遮罩页面全部文本
+				maskLevel: "moderate",
+				// 单次录制最大时长（毫秒）
+				maxDuration: 300000,
+				// 需要排除录制的元素 CSS 选择器，例如 ".sensitive-widget"
+				blockSelector: "",
+			},
 		},
 		// 51la 统计配置
 		la51Analytics: {

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -184,6 +184,8 @@ export const siteConfig: SiteConfig = {
 			scriptUrl: "https://cloud.umami.is/script.js",
 			// 是否追踪出站链接
 			trackOutboundLinks: true,
+			// 是否收集浏览器性能指标
+			collectWebVitals: false,
 		},
 		// 51la 统计配置
 		la51Analytics: {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -109,6 +109,7 @@ const siteLang = lang.replace("_", "-");
           websiteId={siteConfig.analytics.umamiAnalytics.websiteId}
           scriptUrl={siteConfig.analytics.umamiAnalytics.scriptUrl}
           trackOutboundLinks={siteConfig.analytics.umamiAnalytics.trackOutboundLinks}
+          collectWebVitals={siteConfig.analytics.umamiAnalytics.collectWebVitals}
           />
         )}
         {siteConfig.analytics?.la51Analytics?.Id && (

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -110,6 +110,7 @@ const siteLang = lang.replace("_", "-");
           scriptUrl={siteConfig.analytics.umamiAnalytics.scriptUrl}
           trackOutboundLinks={siteConfig.analytics.umamiAnalytics.trackOutboundLinks}
           collectWebVitals={siteConfig.analytics.umamiAnalytics.collectWebVitals}
+          relpays={siteConfig.analytics.umamiAnalytics.relpays}
           />
         )}
         {siteConfig.analytics?.la51Analytics?.Id && (

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -108,6 +108,7 @@ const siteLang = lang.replace("_", "-");
           <UmamiAnalytics
           websiteId={siteConfig.analytics.umamiAnalytics.websiteId}
           scriptUrl={siteConfig.analytics.umamiAnalytics.scriptUrl}
+          trackOutboundLinks={siteConfig.analytics.umamiAnalytics.trackOutboundLinks}
           />
         )}
         {siteConfig.analytics?.la51Analytics?.Id && (

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -118,6 +118,7 @@ export type SiteConfig = {
 		umamiAnalytics?: {
 			websiteId?: string; // Umami Website ID
 			scriptUrl?: string; // Umami JS地址，支持使用自建
+			trackOutboundLinks?: boolean; // 是否追踪出站链接点击事件，默认 true
 		};
 		la51Analytics?: {
 			Id?: string; // 51la 统计 ID

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -120,6 +120,13 @@ export type SiteConfig = {
 			scriptUrl?: string; // Umami JS地址，支持使用自建
 			trackOutboundLinks?: boolean; // 是否追踪出站链接点击事件，默认 true
 			collectWebVitals?: boolean; // 是否自动收集访客浏览器核心网页指标，默认 false
+			relpays?: {
+				enabled?: boolean; // 是否启用会话回放，默认 false
+				sampleRate?: number; // 录制会话采样率，范围 0-1，默认 0.15
+				maskLevel?: "moderate" | "strict"; // 隐私遮罩级别，默认 moderate
+				maxDuration?: number; // 单次录制最大时长（毫秒），默认 300000
+				blockSelector?: string; // 需要完全排除录制的元素 CSS 选择器
+			};
 		};
 		la51Analytics?: {
 			Id?: string; // 51la 统计 ID

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -119,6 +119,7 @@ export type SiteConfig = {
 			websiteId?: string; // Umami Website ID
 			scriptUrl?: string; // Umami JS地址，支持使用自建
 			trackOutboundLinks?: boolean; // 是否追踪出站链接点击事件，默认 true
+			collectWebVitals?: boolean; // 是否自动收集访客浏览器核心网页指标，默认 false
 		};
 		la51Analytics?: {
 			Id?: string; // 51la 统计 ID


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->
无

## Changes

为 Umami Analytics 新增了三个功能及设置项：
- [浏览器性能指标收集](https://docs.umami.is/docs/performance)
- [出站链接追踪](https://docs.umami.is/docs/track-outbound-links)
- [Replays](https://docs.umami.is/docs/replays)

其中出站链接追踪功能根据 [Umami 文档](https://docs.umami.is/docs/track-outbound-links)使用自定义事件实现


## How To Test

<!-- Please describe how you tested your changes. -->
配置`siteConfig.ts`中的设置项并查看 Umami 后台数据情况

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->

同时更新了文档，参见：CuteLeaf/Firefly-Docs#4
