### PR TITLE
Fix link overflow

### DIFF
--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -1,6 +1,8 @@
 @reference "tailwindcss";
 
 .custom-md {
+  overflow-wrap: break-word;
+
   h1 {
     @apply text-3xl;
   }
@@ -30,6 +32,7 @@
     @apply relative bg-none font-medium text-(--primary) underline decoration-(--link-underline) decoration-1 decoration-dashed underline-offset-4;
     box-decoration-break: clone;
     -webkit-box-decoration-break: clone;
+    word-break: break-word;
 
     &:hover,
     &:active {


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

手机端，长文本(链接)容易溢出屏幕
问题截图：
<img width="592" height="383" alt="image" src="https://github.com/user-attachments/assets/fd36e868-23e2-497b-8d0e-d2579293fe3f" />


## Changes

- [x] 1.1 在 `src/styles/markdown.css` 的 `.custom-md` 规则中添加 `overflow-wrap: break-word;` 属性，确保长字符串在容器边界自动换行
- [x] 1.2 在 `src/styles/markdown.css` 的 `.custom-md a:not(.no-styling)` 规则中添加 `word-break: break-word;` 属性，作为兼容性后备确保长链接在所有浏览器中正确断行


## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

修复后效果
<img width="609" height="374" alt="image" src="https://github.com/user-attachments/assets/4c6f6c70-fcf4-44a9-8aaf-b324e36128e6" />



## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
