### PR TITLE
:bug: fix(banner): prevent title overflow on mobile with responsive f…

### DIFF
--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -631,7 +631,7 @@ const bannerCarouselInterval = Math.max(
             <div class="w-4/5 lg:w-3/4 text-center mb-0">
                 <div class="flex flex-col">
                     {backgroundWallpaper.banner?.homeText?.title && (
-                        <div class="banner-title font-bold text-white mb-2 lg:mb-4 leading-tight" style={{ fontSize: backgroundWallpaper.banner.homeText.titleSize || "3rem" }}>
+                        <div class="banner-title font-bold text-white mb-2 lg:mb-4 leading-tight" style={{ '--banner-title-size': backgroundWallpaper.banner.homeText.titleSize || "3rem" }}>
                             {backgroundWallpaper.banner.homeText.title}
                         </div>
                     )}

--- a/src/styles/banner-title.css
+++ b/src/styles/banner-title.css
@@ -1,6 +1,12 @@
 /* 横幅文字阴影 - 更柔和的扩散效果 */
 .banner-title {
     text-shadow: 0 4px 24px rgba(0, 0, 0, 0.6);
+    /* 防止大字体标题溢出容器 */
+    overflow-wrap: break-word;
+    word-break: break-word;
+    /* 响应式字体大小：取用户配置值与视口宽度10%中的较小值，防止小屏幕溢出 */
+    font-size: var(--banner-title-size, 3rem);
+    font-size: min(var(--banner-title-size, 3rem), 10vw);
 }
 
 .banner-subtitle {

--- a/src/styles/layout-styles.css
+++ b/src/styles/layout-styles.css
@@ -22,6 +22,9 @@ html.is-page-transitioning .banner-home-text-overlay {
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.7);
     animation: banner-fadeInUp 0.3s ease-out;
     font-weight: bold;
+    /* 防止大字体标题溢出容器 */
+    overflow-wrap: break-word;
+    word-break: break-word;
 }
 
 .banner-subtitle {
@@ -96,7 +99,7 @@ html.is-page-transitioning .banner-home-text-overlay {
     
     /* 标题字体优化 */
     .banner-title {
-        font-size: 3.2rem !important; /* 增大字体大小 */
+        font-size: min(var(--banner-title-size, 3rem), 10vw) !important;
         line-height: 1.1 !important;
         margin-bottom: 0.5rem !important;
         text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.8) !important; /* 增强阴影 */
@@ -145,19 +148,19 @@ html.is-page-transitioning .banner-home-text-overlay {
     
     /* 标题字体优化 */
     .banner-title {
-        font-size: 3.8rem !important; /* 增大字体大小 */
+        font-size: min(var(--banner-title-size, 3rem), 10vw) !important;
         line-height: 1.1 !important;
         margin-bottom: 0.75rem !important;
         text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.8) !important;
     }
-    
+
     /* 副标题字体优化 */
     .banner-subtitle {
         font-size: 1.125rem !important;
         line-height: 1.4 !important;
         text-shadow: 1px 1px 4px rgba(0, 0, 0, 0.7) !important;
     }
-    
+
 }
 
 /* 移动端横幅优化 - 超大屏手机/小平板 (641px - 767px) */
@@ -194,7 +197,7 @@ html.is-page-transitioning .banner-home-text-overlay {
     
     /* 标题字体优化 */
     .banner-title {
-        font-size: 3.9rem !important;
+        font-size: min(var(--banner-title-size, 3rem), 8vw) !important;
         line-height: 1.1 !important;
         margin-bottom: 0.85rem !important;
         text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.8) !important;
@@ -242,7 +245,7 @@ html.is-page-transitioning .banner-home-text-overlay {
     
     /* 标题字体优化 */
     .banner-title {
-        font-size: 4rem !important;
+        font-size: min(var(--banner-title-size, 3rem), 7vw) !important;
         line-height: 1.1 !important;
         margin-bottom: 1rem !important;
         text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.8) !important;
@@ -451,7 +454,7 @@ html.is-page-transitioning .banner-home-text-overlay {
     }
 
     .banner-title {
-        font-size: 2.2rem !important; /* 增大字体大小 */
+        font-size: min(var(--banner-title-size, 3rem), 6vw) !important;
         line-height: 1.3;
     }
 
@@ -498,16 +501,16 @@ html.is-page-transitioning .banner-home-text-overlay {
     }
     
     .banner-title {
-        font-size: 2.8rem !important; /* 增大字体大小 */
+        font-size: min(var(--banner-title-size, 3rem), 10vw) !important;
         line-height: 1.1 !important;
         margin-bottom: 0.5rem !important;
     }
-    
+
     .banner-subtitle {
         font-size: 0.9rem !important;
         line-height: 1.2 !important;
     }
-    
+
 }
 
 /* 小高度屏幕 (高度 501px - 600px) */
@@ -525,7 +528,7 @@ html.is-page-transitioning .banner-home-text-overlay {
     }
     
     .banner-title {
-        font-size: 3.2rem !important; /* 增大字体大小 */
+        font-size: min(var(--banner-title-size, 3rem), 10vw) !important;
         line-height: 1.1 !important;
         margin-bottom: 0.75rem !important;
     }
@@ -552,7 +555,7 @@ html.is-page-transitioning .banner-home-text-overlay {
     }
     
     .banner-title {
-        font-size: 3.8rem !important; /* 增大字体大小 */
+        font-size: min(var(--banner-title-size, 3rem), 10vw) !important;
         line-height: 1.1 !important;
         margin-bottom: 1rem !important;
     }
@@ -579,7 +582,7 @@ html.is-page-transitioning .banner-home-text-overlay {
     }
     
     .banner-title {
-        font-size: 2.8rem !important; /* 增大字体大小 */
+        font-size: min(var(--banner-title-size, 3rem), 6vw) !important;
         line-height: 1.1 !important;
         margin-bottom: 0.5rem !important;
     }


### PR DESCRIPTION
…ont-size

## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

问题截图：
<img width="873" height="1920" alt="9d5e45918f51ff10ba1526e5aa0bd8c3_720" src="https://github.com/user-attachments/assets/3de97e68-7e4e-4de7-a05d-491d30a8e8ad" />


## Changes

- [x] 1.1 在 `src/styles/banner-title.css` 中为 `.banner-title` 添加 `overflow-wrap: break-word` 和 `word-break: break-word` 属性
- [x] 1.2 在 `src/styles/banner-title.css` 中为 `.banner-title` 添加字体大小响应式计算：`font-size: min(var(--banner-title-size, 3rem), 10vw)` 并保留内联 `font-size` 作为 fallback
- [x] 1.3 在 `src/styles/layout-styles.css` 中更新各响应式断点的 `.banner-title` 样式，确保不再硬编码覆盖字体大小，而是使用 `min(var(--banner-title-size), <breakpoint-max>)` 方式


## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

修复后截图：
<img width="873" height="1920" alt="ce94fad52325126f46a9fe7cd5c127db_720" src="https://github.com/user-attachments/assets/b004b663-bec3-4484-ace9-bc5cd059f8d9" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
