### PR TITLE
:sparkles: feat(markdown): support plantuml

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -24,15 +24,18 @@ import { pluginLanguageBadge } from "expressive-code-language-badge"; /* Languag
 import { pluginCollapsible } from "expressive-code-collapsible"; /* Collapsible */
 import { GithubCardComponent } from "./src/plugins/rehype-component-github-card.mjs";
 import { rehypeMermaid } from "./src/plugins/rehype-mermaid.mjs";
+import { rehypePlantuml } from "./src/plugins/rehype-plantuml.mjs";
 import { parseDirectiveNode } from "./src/plugins/remark-directive-rehype.js";
 import { remarkExcerpt } from "./src/plugins/remark-excerpt.js";
 import { remarkMermaid } from "./src/plugins/remark-mermaid.js";
+import { remarkPlantuml } from "./src/plugins/remark-plantuml.js";
 import { remarkReadingTime } from "./src/plugins/remark-reading-time.mjs";
 import mdx from "@astrojs/mdx";
 import rehypeEmailProtection from "./src/plugins/rehype-email-protection.mjs";
 import rehypeExternalLinks from "./src/plugins/rehype-external-links.mjs";
 import rehypeFigure from "./src/plugins/rehype-figure.mjs";
 import { remarkImageGrid } from "./src/plugins/remark-image-grid.js";
+import { plantumlConfig } from "./src/config";
 
 // https://astro.build/config
 export default defineConfig({
@@ -194,12 +197,14 @@ export default defineConfig({
 			remarkSectionize,
 			parseDirectiveNode,
 			remarkMermaid,
+			[remarkPlantuml, plantumlConfig],
 		],
 		rehypePlugins: [
 			[rehypeKatex, { katex }],
 			[rehypeCallouts, { theme: siteConfig.rehypeCallouts.theme }],
 			rehypeSlug,
 			rehypeMermaid,
+			rehypePlantuml,
 			rehypeFigure,
 			[rehypeExternalLinks, { siteUrl: siteConfig.site_url }],
 			[rehypeEmailProtection, { method: "base64" }], // 邮箱保护插件，支持 'base64' 或 'rot13'

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "node-html-parser": "^7.1.0",
     "overlayscrollbars": "^2.15.1",
     "pagefind": "^1.5.2",
+    "pako": "^2.1.0",
     "photoswipe": "^5.4.4",
     "qrcode": "^1.5.4",
     "reading-time": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       pagefind:
         specifier: ^1.5.2
         version: 1.5.2
+      pako:
+        specifier: ^2.1.0
+        version: 2.1.0
       photoswipe:
         specifier: ^5.4.4
         version: 5.4.4
@@ -3965,6 +3968,9 @@ packages:
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -10099,6 +10105,8 @@ snapshots:
       '@pagefind/windows-x64': 1.5.2
 
   pako@0.2.9: {}
+
+  pako@2.1.0: {}
 
   parent-module@1.0.1:
     dependencies:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -14,6 +14,7 @@ export type {
 	LicenseConfig,
 	MusicPlayerConfig,
 	NavBarConfig,
+	PlantUMLConfig,
 	ProfileConfig,
 	SakuraConfig,
 	SidebarLayoutConfig,
@@ -41,6 +42,7 @@ export { licenseConfig } from "./licenseConfig"; // 许可证配置
 export { musicPlayerConfig } from "./musicConfig"; // 音乐播放器配置
 export { navBarConfig, navBarSearchConfig } from "./navBarConfig"; // 导航栏配置与搜索配置
 export { live2dModelConfig, spineModelConfig } from "./pioConfig"; // 看板娘配置
+export { plantumlConfig } from "./plantumlConfig"; // PlantUML 图表配置
 export { profileConfig } from "./profileConfig"; // 用户资料配置
 export { sakuraConfig } from "./sakuraConfig"; // 樱花特效配置
 // 布局配置

--- a/src/config/plantumlConfig.ts
+++ b/src/config/plantumlConfig.ts
@@ -1,0 +1,37 @@
+import type { PlantUMLConfig } from "../types/config";
+
+/**
+ * PlantUML 图表渲染配置
+ *
+ * 用于控制 markdown 文章中 `plantuml` 代码块到 PlantUML 服务器 SVG 图片的
+ * 构建时编码与客户端渲染行为。支持明暗双主题与自建 PlantUML 服务器。
+ *
+ * @see https://plantuml.com/zh/theme
+ * @see https://plantuml.com/zh/server
+ */
+export const plantumlConfig: PlantUMLConfig = {
+	/**
+	 * 是否启用 PlantUML 渲染能力。
+	 * 关闭时 `plantuml` 代码块退化为普通代码高亮，由 Expressive Code 处理。
+	 */
+	enable: true,
+
+	/**
+	 * PlantUML 服务器地址（不含尾部斜杠也可，会自动归一化）。
+	 * 默认使用官方公共服务器；敏感内容请部署自建服务器（例如
+	 * `plantuml/plantuml-server` Docker 镜像），并把此字段替换为自建地址。
+	 */
+	server: "https://www.plantuml.com/plantuml",
+
+	/**
+	 * 亮色模式下注入到 PlantUML 源码的主题名（对应 `!theme <name>`）。
+	 * 留空字符串表示不注入任何主题，使用 PlantUML 默认外观。
+	 */
+	lightTheme: "",
+
+	/**
+	 * 暗色模式下注入到 PlantUML 源码的主题名（对应 `!theme <name>`）。
+	 * 留空字符串表示不注入主题；默认使用内置的 `cyborg` 暗色主题。
+	 */
+	darkTheme: "cyborg",
+};

--- a/src/plugins/plantuml-encoder.js
+++ b/src/plugins/plantuml-encoder.js
@@ -1,0 +1,148 @@
+import pako from "pako";
+
+/**
+ * PlantUML 编码字母表：`0-9A-Za-z-_`。
+ * 与标准 base64 不同，PlantUML 使用自定义映射以便放入 URL path 段。
+ * @see https://plantuml.com/text-encoding
+ */
+const PLANTUML_ALPHABET =
+	"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_";
+
+/**
+ * 将 0-63 的 6-bit 数值映射到 PlantUML 字母表字符。
+ *
+ * @param {number} value 取值范围 [0, 63]
+ * @returns {string} 单字符的编码
+ */
+function encode6bit(value) {
+	return PLANTUML_ALPHABET.charAt(value & 0x3f);
+}
+
+/**
+ * 把 3 字节打包为 4 个 PlantUML 编码字符。
+ * 不足 3 字节时调用方需用 0 补齐（与原始 PlantUML 算法一致）。
+ *
+ * @param {number} b1 第 1 字节（0-255）
+ * @param {number} b2 第 2 字节（0-255）
+ * @param {number} b3 第 3 字节（0-255）
+ * @returns {string} 长度为 4 的编码串
+ */
+function append3bytes(b1, b2, b3) {
+	const c1 = b1 >> 2;
+	const c2 = ((b1 & 0x3) << 4) | (b2 >> 4);
+	const c3 = ((b2 & 0xf) << 2) | (b3 >> 6);
+	const c4 = b3 & 0x3f;
+	return encode6bit(c1) + encode6bit(c2) + encode6bit(c3) + encode6bit(c4);
+}
+
+/**
+ * 使用 PlantUML 自定义 base64 字母表对字节数组进行编码。
+ * 与标准 base64 相比：字母表不同（PlantUML 使用 `0-9A-Za-z-_`）、
+ * 末尾不追加 `=` 填充。
+ *
+ * @param {Uint8Array} bytes 待编码的字节数组
+ * @returns {string} PlantUML 编码后的字符串
+ */
+function encode64(bytes) {
+	let result = "";
+	const length = bytes.length;
+	for (let i = 0; i < length; i += 3) {
+		if (i + 2 === length) {
+			result += append3bytes(bytes[i], bytes[i + 1], 0);
+		} else if (i + 1 === length) {
+			result += append3bytes(bytes[i], 0, 0);
+		} else {
+			result += append3bytes(bytes[i], bytes[i + 1], bytes[i + 2]);
+		}
+	}
+	return result;
+}
+
+/**
+ * 对 PlantUML 源码进行 PlantUML 专用编码：
+ *   1. 将源码按 UTF-8 编码为字节数组
+ *   2. 对字节进行 raw DEFLATE 压缩（无 zlib 头）
+ *   3. 用 PlantUML base64 字母表（`0-9A-Za-z-_`）将压缩结果编码为字符串
+ * 该结果可直接拼接到 PlantUML 服务器的 `/svg/`、`/png/` 等路径之后。
+ *
+ * @param {string} source 原始 PlantUML 源码（包含或不包含 `@startuml/@enduml` 均可）
+ * @returns {string} 可用于 URL 的编码串
+ * @throws {TypeError} 当 `source` 不是字符串时抛出
+ */
+export function encodePlantUML(source) {
+	if (typeof source !== "string") {
+		throw new TypeError(
+			`encodePlantUML expects a string, got ${typeof source}`,
+		);
+	}
+	const utf8Bytes = new TextEncoder().encode(source);
+	const deflated = pako.deflateRaw(utf8Bytes, { level: 9 });
+	return encode64(deflated);
+}
+
+/**
+ * 判断源码是否已经包含主题/背景色相关的显式指令。
+ * 用于避免在作者显式指定主题时进行二次注入。
+ *
+ * @param {string} source PlantUML 源码
+ * @returns {boolean} true 表示源码已包含 `!theme` 或 `skinparam backgroundColor`
+ */
+function hasExplicitTheme(source) {
+	return (
+		/^\s*!theme\s+\S+/m.test(source) ||
+		/^\s*skinparam\s+backgroundColor\b/im.test(source)
+	);
+}
+
+/**
+ * 在 PlantUML 源码头部注入 `!theme <themeName>` 指令。
+ *
+ * 注入规则：
+ *   - `themeName` 为空串或仅空白时：原样返回
+ *   - 源码已包含 `!theme` 或 `skinparam backgroundColor` 时：原样返回（尊重作者显式设置）
+ *   - 源码首行为 `@startuml[...]` 时：在该行之后插入主题指令
+ *   - 源码未显式声明 `@startuml` 时：在源码最前面插入主题指令
+ *
+ * @param {string} source 原始 PlantUML 源码
+ * @param {string} themeName PlantUML 主题名（例如 "cyborg"、"materia"）
+ * @returns {string} 可能已注入 `!theme` 的源码
+ */
+export function injectTheme(source, themeName) {
+	if (typeof source !== "string") {
+		throw new TypeError(
+			`injectTheme expects a string source, got ${typeof source}`,
+		);
+	}
+	if (!themeName?.trim()) {
+		return source;
+	}
+	if (hasExplicitTheme(source)) {
+		return source;
+	}
+	const themeDirective = `!theme ${themeName.trim()}`;
+	const startumlMatch = source.match(/^[^\S\r\n]*@startuml[^\r\n]*\r?\n?/);
+	if (startumlMatch) {
+		const insertAt = startumlMatch.index + startumlMatch[0].length;
+		return `${source.slice(0, insertAt)}${themeDirective}\n${source.slice(insertAt)}`;
+	}
+	return `${themeDirective}\n${source}`;
+}
+
+/**
+ * 拼接 PlantUML 服务器地址与编码串生成可直接访问的 SVG URL。
+ * 自动去除 `server` 尾部的斜杠，避免出现 `//svg/`。
+ *
+ * @param {string} server PlantUML 服务器根地址，例如 `https://www.plantuml.com/plantuml`
+ * @param {string} encoded 经 {@link encodePlantUML} 产生的编码串
+ * @returns {string} 形如 `<server>/svg/<encoded>` 的完整 URL
+ */
+export function buildUrl(server, encoded) {
+	if (typeof server !== "string" || !server.trim()) {
+		throw new TypeError("buildUrl expects a non-empty server string");
+	}
+	if (typeof encoded !== "string" || !encoded.trim()) {
+		throw new TypeError("buildUrl expects a non-empty encoded string");
+	}
+	const normalizedServer = server.replace(/\/+$/, "");
+	return `${normalizedServer}/svg/${encoded}`;
+}

--- a/src/plugins/plantuml-render-script.js
+++ b/src/plugins/plantuml-render-script.js
@@ -1,0 +1,447 @@
+/*
+ * plantuml 图表客户端渲染与交互脚本
+ *
+ * 职责：
+ *   - 根据 <html> 的 `dark` class，动态切换 .plantuml-image 的 data-light-src / data-dark-src
+ *   - 加载失败时替换容器内容为错误提示 + 重试按钮
+ *   - 为每个容器提供 pan-zoom（CSS transform）与全屏查看能力
+ *   - 响应 astro:page-load（Swup）与主题切换事件
+ *
+ * 通过 IIFE + window.plantumlInitialized 防止在 Swup 场景下重复初始化。
+ */
+(() => {
+	if (window.plantumlInitialized) {
+		return;
+	}
+	window.plantumlInitialized = true;
+
+	const MIN_SCALE = 0.5;
+	const MAX_SCALE = 5;
+	const SCALE_STEP = 1.2;
+
+	/** @type {Set<HTMLElement>} 当前已打开的全屏 overlay 集合（跨页面清理用） */
+	const fullscreenOverlays = new Set();
+
+	/**
+	 * 按当前主题为所有图片选择正确的 src。
+	 * @returns {void}
+	 */
+	function applyTheme() {
+		const isDark = document.documentElement.classList.contains("dark");
+		const images = document.querySelectorAll(".plantuml-image");
+		images.forEach((img) => {
+			const light = img.getAttribute("data-light-src") || "";
+			const dark = img.getAttribute("data-dark-src") || light;
+			const next = isDark ? dark : light;
+			if (next && img.getAttribute("src") !== next) {
+				img.setAttribute("src", next);
+			}
+		});
+	}
+
+	/**
+	 * 为单个图片绑定加载失败的降级 UI。
+	 * @param {HTMLImageElement} img 图片元素
+	 * @param {HTMLElement} container .plantuml-diagram-container
+	 */
+	function bindErrorHandler(img, container) {
+		if (img.dataset.errorBound === "true") return;
+		img.dataset.errorBound = "true";
+		img.addEventListener("error", () => {
+			if (container.dataset.errorShown === "true") return;
+			container.dataset.errorShown = "true";
+			const wrapper = container.querySelector(".plantuml-wrapper");
+			if (!wrapper) return;
+			wrapper.innerHTML = "";
+			const errorBox = document.createElement("div");
+			errorBox.className = "plantuml-error";
+			const msg = document.createElement("p");
+			msg.textContent = "PlantUML 图表加载失败，请检查网络或服务器状态";
+			const retry = document.createElement("button");
+			retry.type = "button";
+			retry.textContent = "重试";
+			retry.addEventListener("click", (event) => {
+				event.preventDefault();
+				event.stopPropagation();
+				delete container.dataset.errorShown;
+				wrapper.innerHTML = "";
+				const newImg = new Image();
+				newImg.className = "plantuml-image";
+				newImg.alt = img.alt;
+				newImg.setAttribute(
+					"data-light-src",
+					img.getAttribute("data-light-src") || "",
+				);
+				newImg.setAttribute(
+					"data-dark-src",
+					img.getAttribute("data-dark-src") || "",
+				);
+				newImg.loading = "lazy";
+				newImg.decoding = "async";
+				wrapper.appendChild(newImg);
+				bindErrorHandler(newImg, container);
+				bindLoadHandler(newImg, container);
+				applyTheme();
+			});
+			errorBox.appendChild(msg);
+			errorBox.appendChild(retry);
+			wrapper.appendChild(errorBox);
+		});
+	}
+
+	/**
+	 * 为单个图片绑定 load 回调，在加载成功后初始化 pan-zoom 与控制栏。
+	 * @param {HTMLImageElement} img 图片元素
+	 * @param {HTMLElement} container .plantuml-diagram-container
+	 */
+	function bindLoadHandler(img, container) {
+		if (img.dataset.loadBound === "true") return;
+		img.dataset.loadBound = "true";
+		const onLoad = () => initInteraction(container);
+		if (img.complete && img.naturalWidth > 0) {
+			queueMicrotask(onLoad);
+		} else {
+			img.addEventListener("load", onLoad, { once: true });
+		}
+	}
+
+	/**
+	 * 初始化指定容器上的缩放、平移、控制栏与双击行为。
+	 * 重入安全：同一容器多次调用不会重复绑定。
+	 *
+	 * @param {HTMLElement} container .plantuml-diagram-container
+	 */
+	function initInteraction(container) {
+		if (container.dataset.interactionInit === "true") return;
+		const img = container.querySelector(".plantuml-image");
+		if (!img) return;
+		container.dataset.interactionInit = "true";
+
+		const state = { scale: 1, translateX: 0, translateY: 0 };
+
+		const applyTransform = () => {
+			img.style.transformOrigin = "center center";
+			img.style.transform = `translate(${state.translateX}px, ${state.translateY}px) scale(${state.scale})`;
+		};
+
+		const clampScale = (next) => Math.min(MAX_SCALE, Math.max(MIN_SCALE, next));
+
+		const reset = () => {
+			state.scale = 1;
+			state.translateX = 0;
+			state.translateY = 0;
+			applyTransform();
+		};
+
+		const zoomBy = (factor, originX, originY) => {
+			const prev = state.scale;
+			const next = clampScale(prev * factor);
+			if (next === prev) return;
+			if (typeof originX === "number" && typeof originY === "number") {
+				const rect = img.getBoundingClientRect();
+				const cx = rect.left + rect.width / 2;
+				const cy = rect.top + rect.height / 2;
+				const dx = originX - cx;
+				const dy = originY - cy;
+				const ratio = next / prev;
+				state.translateX = state.translateX - dx * (ratio - 1);
+				state.translateY = state.translateY - dy * (ratio - 1);
+			}
+			state.scale = next;
+			applyTransform();
+		};
+
+		// 控制栏按钮
+		const controls = document.createElement("div");
+		controls.className = "plantuml-controls";
+		const buttons = [
+			{
+				label: "+",
+				title: "放大",
+				action: () => zoomBy(SCALE_STEP),
+			},
+			{
+				label: "\u2212",
+				title: "缩小",
+				action: () => zoomBy(1 / SCALE_STEP),
+			},
+			{ label: "\u21BA", title: "重置", action: reset },
+			{
+				label: "\u26F6",
+				title: "全屏",
+				action: () => openFullscreen(container),
+			},
+		];
+		buttons.forEach((btn) => {
+			const el = document.createElement("button");
+			el.type = "button";
+			el.className = "plantuml-ctrl-btn";
+			el.textContent = btn.label;
+			el.title = btn.title;
+			el.addEventListener("click", (event) => {
+				event.preventDefault();
+				event.stopPropagation();
+				btn.action();
+			});
+			controls.appendChild(el);
+		});
+		container.appendChild(controls);
+
+		// 滚轮缩放
+		container.addEventListener(
+			"wheel",
+			(event) => {
+				if (!event.ctrlKey && !event.metaKey) {
+					// 保持与 mermaid 一致：悬停时直接缩放
+				}
+				event.preventDefault();
+				const factor = event.deltaY < 0 ? SCALE_STEP : 1 / SCALE_STEP;
+				zoomBy(factor, event.clientX, event.clientY);
+			},
+			{ passive: false },
+		);
+
+		// 拖拽平移
+		let isDragging = false;
+		let startX = 0;
+		let startY = 0;
+		let startTx = 0;
+		let startTy = 0;
+
+		const onPointerDown = (event) => {
+			if (event.button !== 0 && event.pointerType !== "touch") return;
+			if (event.target.closest(".plantuml-controls")) return;
+			isDragging = true;
+			startX = event.clientX;
+			startY = event.clientY;
+			startTx = state.translateX;
+			startTy = state.translateY;
+			container.setPointerCapture?.(event.pointerId);
+			container.style.cursor = "grabbing";
+		};
+		const onPointerMove = (event) => {
+			if (!isDragging) return;
+			state.translateX = startTx + (event.clientX - startX);
+			state.translateY = startTy + (event.clientY - startY);
+			applyTransform();
+		};
+		const onPointerUp = (event) => {
+			if (!isDragging) return;
+			isDragging = false;
+			container.releasePointerCapture?.(event.pointerId);
+			container.style.cursor = "";
+		};
+		container.addEventListener("pointerdown", onPointerDown);
+		container.addEventListener("pointermove", onPointerMove);
+		container.addEventListener("pointerup", onPointerUp);
+		container.addEventListener("pointercancel", onPointerUp);
+
+		// 双击放大/重置
+		container.addEventListener("dblclick", (event) => {
+			if (event.target.closest(".plantuml-controls")) return;
+			if (state.scale !== 1) {
+				reset();
+			} else {
+				zoomBy(SCALE_STEP * SCALE_STEP, event.clientX, event.clientY);
+			}
+		});
+
+		applyTransform();
+	}
+
+	/**
+	 * 打开全屏 overlay 展示指定容器中的图片。
+	 * @param {HTMLElement} container .plantuml-diagram-container
+	 */
+	function openFullscreen(container) {
+		const sourceImg = container.querySelector(".plantuml-image");
+		if (!sourceImg) return;
+
+		const overlay = document.createElement("div");
+		overlay.className = "plantuml-fullscreen-overlay";
+
+		const content = document.createElement("div");
+		content.className = "plantuml-fs-content";
+
+		const img = document.createElement("img");
+		img.src = sourceImg.src;
+		img.alt = sourceImg.alt;
+		img.draggable = false;
+		content.appendChild(img);
+
+		const fsControls = document.createElement("div");
+		fsControls.className = "plantuml-fs-controls";
+
+		const state = { scale: 1, tx: 0, ty: 0 };
+		const apply = () => {
+			img.style.transformOrigin = "center center";
+			img.style.transform = `translate(${state.tx}px, ${state.ty}px) scale(${state.scale})`;
+		};
+		const zoom = (factor, originX, originY) => {
+			const prev = state.scale;
+			const next = Math.min(MAX_SCALE, Math.max(MIN_SCALE, prev * factor));
+			if (next === prev) return;
+			if (typeof originX === "number" && typeof originY === "number") {
+				const rect = img.getBoundingClientRect();
+				const cx = rect.left + rect.width / 2;
+				const cy = rect.top + rect.height / 2;
+				const dx = originX - cx;
+				const dy = originY - cy;
+				const ratio = next / prev;
+				state.tx = state.tx - dx * (ratio - 1);
+				state.ty = state.ty - dy * (ratio - 1);
+			}
+			state.scale = next;
+			apply();
+		};
+		const resetState = () => {
+			state.scale = 1;
+			state.tx = 0;
+			state.ty = 0;
+			apply();
+		};
+
+		const close = () => {
+			document.removeEventListener("keydown", onKeyDown);
+			overlay.remove();
+			fullscreenOverlays.delete(overlay);
+		};
+		const onKeyDown = (event) => {
+			if (event.key === "Escape") {
+				close();
+			}
+		};
+
+		const fsButtons = [
+			{ label: "+", title: "放大", action: () => zoom(SCALE_STEP) },
+			{
+				label: "\u2212",
+				title: "缩小",
+				action: () => zoom(1 / SCALE_STEP),
+			},
+			{ label: "\u21BA", title: "重置", action: resetState },
+			{ label: "\u2715", title: "关闭", action: close },
+		];
+		fsButtons.forEach((btn) => {
+			const el = document.createElement("button");
+			el.type = "button";
+			el.className = "plantuml-ctrl-btn";
+			el.textContent = btn.label;
+			el.title = btn.title;
+			el.addEventListener("click", (event) => {
+				event.preventDefault();
+				event.stopPropagation();
+				btn.action();
+			});
+			fsControls.appendChild(el);
+		});
+
+		// overlay 内滚轮缩放
+		content.addEventListener(
+			"wheel",
+			(event) => {
+				event.preventDefault();
+				const factor = event.deltaY < 0 ? SCALE_STEP : 1 / SCALE_STEP;
+				zoom(factor, event.clientX, event.clientY);
+			},
+			{ passive: false },
+		);
+
+		// overlay 内拖拽平移
+		let dragging = false;
+		let sx = 0;
+		let sy = 0;
+		let stx = 0;
+		let sty = 0;
+		content.addEventListener("pointerdown", (event) => {
+			if (event.target.closest(".plantuml-fs-controls")) return;
+			dragging = true;
+			sx = event.clientX;
+			sy = event.clientY;
+			stx = state.tx;
+			sty = state.ty;
+			content.setPointerCapture?.(event.pointerId);
+		});
+		content.addEventListener("pointermove", (event) => {
+			if (!dragging) return;
+			state.tx = stx + (event.clientX - sx);
+			state.ty = sty + (event.clientY - sy);
+			apply();
+		});
+		const endDrag = (event) => {
+			if (!dragging) return;
+			dragging = false;
+			content.releasePointerCapture?.(event.pointerId);
+		};
+		content.addEventListener("pointerup", endDrag);
+		content.addEventListener("pointercancel", endDrag);
+
+		// 背景点击关闭
+		overlay.addEventListener("click", (event) => {
+			if (event.target === overlay) {
+				close();
+			}
+		});
+
+		overlay.appendChild(content);
+		overlay.appendChild(fsControls);
+		document.body.appendChild(overlay);
+		fullscreenOverlays.add(overlay);
+		document.addEventListener("keydown", onKeyDown);
+	}
+
+	/**
+	 * 清理全部已打开的全屏 overlay；用于 Swup 页面切换前。
+	 */
+	function closeAllOverlays() {
+		fullscreenOverlays.forEach((overlay) => {
+			overlay.remove();
+		});
+		fullscreenOverlays.clear();
+	}
+
+	/**
+	 * 扫描当前文档中的所有 .plantuml-diagram-container，初始化交互与降级。
+	 */
+	function initAll() {
+		const containers = document.querySelectorAll(".plantuml-diagram-container");
+		containers.forEach((container) => {
+			const img = container.querySelector(".plantuml-image");
+			if (!img) return;
+			bindErrorHandler(img, container);
+			bindLoadHandler(img, container);
+		});
+		applyTheme();
+	}
+
+	// 监听主题切换
+	const themeObserver = new MutationObserver((mutations) => {
+		for (const mutation of mutations) {
+			if (
+				mutation.type === "attributes" &&
+				mutation.attributeName === "class"
+			) {
+				applyTheme();
+				break;
+			}
+		}
+	});
+	themeObserver.observe(document.documentElement, {
+		attributes: true,
+		attributeFilter: ["class"],
+	});
+
+	// Swup 导航清理
+	document.addEventListener("astro:before-preparation", closeAllOverlays);
+	document.addEventListener("astro:page-load", () => {
+		closeAllOverlays();
+		initAll();
+	});
+
+	// 初次加载
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", initAll, { once: true });
+	} else {
+		initAll();
+	}
+})();

--- a/src/plugins/rehype-figure.mjs
+++ b/src/plugins/rehype-figure.mjs
@@ -15,6 +15,17 @@ export default function rehypeFigure() {
 				return;
 			}
 
+			// 跳过已由其它插件接管渲染的图片（例如 plantuml）
+			const classRaw = node.properties?.className;
+			const classNames = Array.isArray(classRaw)
+				? classRaw
+				: typeof classRaw === "string"
+					? classRaw.split(/\s+/)
+					: [];
+			if (classNames.includes("plantuml-image")) {
+				return;
+			}
+
 			const imgProps = { ...node.properties };
 
 			// 添加 referrerpolicy（如果需要）解决 403 问题

--- a/src/plugins/rehype-plantuml.mjs
+++ b/src/plugins/rehype-plantuml.mjs
@@ -1,0 +1,113 @@
+import { h } from "hastscript";
+import { visit } from "unist-util-visit";
+import plantumlRenderScript from "./plantuml-render-script.js?raw";
+
+/**
+ * 从 HAST 节点递归提取所有文本内容，作为 `<img>` 的 alt 回退文案。
+ *
+ * @param {import('hast').Node} node 节点
+ * @returns {string} 拼接后的文本
+ */
+function extractText(node) {
+	if (node.type === "text") return node.value || "";
+	if (node.children) return node.children.map(extractText).join("");
+	return "";
+}
+
+/**
+ * 生成当前 HAST 节点的随机 id，避免同一页多个图表冲突。
+ *
+ * @returns {string}
+ */
+function generateId() {
+	const rand = Math.random().toString(36).slice(2, 8);
+	return `plantuml-${rand}`;
+}
+
+/** 已注入客户端脚本的 tree 集合，用于避免同一 tree 多次注入 */
+const scriptInjectedTrees = new WeakSet();
+
+/**
+ * rehype 插件：把 `div.plantuml-container`（由 remark-plantuml 标记）改写为
+ * 可交互的 `.plantuml-diagram-container`，并在每棵 tree 末尾注入一次客户端
+ * 渲染脚本，负责主题切换、加载失败降级与缩放/全屏控制。
+ *
+ * @returns {(tree: import('hast').Root) => void} rehype transformer
+ */
+export function rehypePlantuml() {
+	return (tree) => {
+		let foundAny = false;
+
+		visit(tree, "element", (node) => {
+			if (node.tagName !== "div" || !node.properties) {
+				return;
+			}
+			const classProp = node.properties.className;
+			const hasMarker = Array.isArray(classProp)
+				? classProp.includes("plantuml-container")
+				: typeof classProp === "string"
+					? classProp.split(/\s+/).includes("plantuml-container")
+					: false;
+			if (!hasMarker) {
+				return;
+			}
+
+			const lightSrc =
+				node.properties["data-plantuml-light"] ||
+				node.properties.dataPlantumlLight ||
+				"";
+			const darkSrc =
+				node.properties["data-plantuml-dark"] ||
+				node.properties.dataPlantumlDark ||
+				lightSrc;
+			let altText =
+				node.properties["data-plantuml-alt"] ||
+				node.properties.dataPlantumlAlt ||
+				"";
+			if (!altText) {
+				altText = extractText(node).trim().slice(0, 200);
+			}
+
+			if (!lightSrc) {
+				return;
+			}
+
+			const diagramId = generateId();
+
+			const img = h("img", {
+				class: "plantuml-image",
+				alt: altText || "PlantUML diagram",
+				src: lightSrc,
+				"data-light-src": lightSrc,
+				"data-dark-src": darkSrc,
+				loading: "lazy",
+				decoding: "async",
+			});
+
+			const wrapper = h(
+				"div",
+				{
+					class: "plantuml-wrapper",
+					id: diagramId,
+				},
+				[img],
+			);
+
+			node.tagName = "div";
+			node.properties = { class: "plantuml-diagram-container" };
+			node.children = [wrapper];
+
+			foundAny = true;
+		});
+
+		if (foundAny && !scriptInjectedTrees.has(tree)) {
+			scriptInjectedTrees.add(tree);
+			const script = h(
+				"script",
+				{ type: "text/javascript" },
+				plantumlRenderScript,
+			);
+			tree.children = [...(tree.children || []), script];
+		}
+	};
+}

--- a/src/plugins/remark-plantuml.js
+++ b/src/plugins/remark-plantuml.js
@@ -1,0 +1,72 @@
+import { visit } from "unist-util-visit";
+import { buildUrl, encodePlantUML, injectTheme } from "./plantuml-encoder.js";
+
+/**
+ * @typedef {Object} RemarkPlantumlOptions
+ * @property {boolean} [enable=true] 是否启用 PlantUML 处理，false 时 plantuml 代码块原样交给下游处理
+ * @property {string} [server="https://www.plantuml.com/plantuml"] PlantUML 服务器地址
+ * @property {string} [lightTheme=""] 亮色模式注入的 PlantUML 主题名，空串不注入
+ * @property {string} [darkTheme=""] 暗色模式注入的 PlantUML 主题名，空串不注入
+ */
+
+/** @type {RemarkPlantumlOptions} */
+const DEFAULT_OPTIONS = {
+	enable: true,
+	server: "https://www.plantuml.com/plantuml",
+	lightTheme: "",
+	darkTheme: "",
+};
+
+/**
+ * 识别 markdown 源中的 ```plantuml``` fenced code block，并在 remark 阶段
+ * 将其转换为一个携带双主题 URL 数据属性的自定义节点，供 rehype 阶段渲染。
+ *
+ * 转换策略：参考 `remark-mermaid.js`，保留 `hChildren`（原始代码作为文本节点）
+ * 以兼容 MDX 编译器对 hProperties 的处理。
+ *
+ * @param {RemarkPlantumlOptions} [options] 插件选项
+ * @returns {(tree: import('mdast').Root) => void} remark transformer
+ */
+export function remarkPlantuml(options = {}) {
+	const config = { ...DEFAULT_OPTIONS, ...options };
+
+	return (tree) => {
+		if (config.enable === false) {
+			return;
+		}
+
+		visit(tree, "code", (node) => {
+			const lang = typeof node.lang === "string" ? node.lang.toLowerCase() : "";
+			if (lang !== "plantuml") {
+				return;
+			}
+
+			const code = typeof node.value === "string" ? node.value : "";
+			if (!code.trim()) {
+				return;
+			}
+
+			const lightSource = injectTheme(code, config.lightTheme);
+			const darkSource = injectTheme(code, config.darkTheme);
+
+			const lightUrl = buildUrl(config.server, encodePlantUML(lightSource));
+			const darkUrl =
+				darkSource === lightSource
+					? lightUrl
+					: buildUrl(config.server, encodePlantUML(darkSource));
+
+			node.type = "plantuml";
+			node.data = {
+				hName: "div",
+				hProperties: {
+					className: ["plantuml-container"],
+					"data-plantuml-light": lightUrl,
+					"data-plantuml-dark": darkUrl,
+					"data-plantuml-alt": code.slice(0, 200),
+				},
+				hChildren: [{ type: "text", value: code }],
+			};
+			node.value = undefined;
+		});
+	};
+}

--- a/src/styles/markdown-extend.styl
+++ b/src/styles/markdown-extend.styl
@@ -440,3 +440,204 @@ a.card-github.fetch-error
     width: 32px
     height: 32px
     font-size: 16px
+
+// PlantUML 图表样式（与 mermaid 视觉对齐，使用 CSS transform 实现 pan-zoom）
+.plantuml-diagram-container
+  position: relative
+  margin: 1rem 0
+  border-radius: 0.75rem
+  overflow: hidden
+  background: var(--card-bg)
+  transition: all 0.3s ease
+  touch-action: none
+
+  &:hover
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1)
+
+    .plantuml-controls
+      opacity: 1
+
+.plantuml-wrapper
+  padding: 1.5rem
+  display: flex
+  justify-content: center
+  align-items: center
+  min-height: 100px
+  max-height: 420px
+  overflow: hidden
+
+.plantuml-image
+  max-width: 100%
+  max-height: 420px
+  height: auto
+  display: block
+  user-select: none
+  -webkit-user-drag: none
+  transition: transform 0.12s ease-out
+  will-change: transform
+
+.plantuml-loading
+  display: flex
+  align-items: center
+  justify-content: center
+  padding: 2rem
+  color: var(--text-color-secondary)
+  font-style: italic
+
+  &::before
+    content: ""
+    width: 20px
+    height: 20px
+    border: 2px solid var(--primary)
+    border-top: 2px solid transparent
+    border-radius: 50%
+    animation: spin 1s linear infinite
+    margin-right: 0.5rem
+
+.plantuml-error
+  color: var(--admonitions-color-warning)
+  background: rgba(239, 68, 68, 0.1)
+  border: 1px solid var(--admonitions-color-warning)
+  border-radius: 0.5rem
+  padding: 1rem
+  margin: 1rem
+  text-align: center
+  font-weight: 500
+
+  p
+    margin: 0 0 0.5rem 0
+
+  button
+    padding: 4px 12px
+    background: var(--primary)
+    color: white
+    border: none
+    border-radius: 4px
+    cursor: pointer
+    transition: all 0.2s ease
+
+    &:hover
+      background: var(--primary-hover)
+      transform: translateY(-1px)
+
+// 深色模式下的 PlantUML 容器背景
+.dark .plantuml-diagram-container
+  background: var(--card-bg)
+
+  .plantuml-image
+    filter: brightness(0.95)
+
+// PlantUML pan-zoom 控制栏
+.plantuml-controls
+  position: absolute
+  top: 8px
+  right: 8px
+  display: flex
+  gap: 4px
+  opacity: 0.5
+  transition: opacity 0.2s ease
+  z-index: 10
+
+  &:hover
+    opacity: 1
+
+.plantuml-ctrl-btn
+  width: 28px
+  height: 28px
+  border: none
+  border-radius: 6px
+  background: var(--btn-regular-bg)
+  color: var(--btn-content)
+  font-size: 14px
+  line-height: 28px
+  text-align: center
+  cursor: pointer
+  padding: 0
+  display: flex
+  align-items: center
+  justify-content: center
+  transition: all 0.15s ease
+  backdrop-filter: blur(8px)
+
+  &:hover
+    background: var(--btn-regular-bg-hover)
+    transform: translateY(-1px)
+
+  &:active
+    background: var(--btn-regular-bg-active)
+    transform: translateY(0)
+
+// PlantUML 全屏遮罩
+.plantuml-fullscreen-overlay
+  position: fixed
+  top: 0
+  left: 0
+  width: 100vw
+  height: 100vh
+  background: rgba(0, 0, 0, 0.85)
+  z-index: 9999
+  display: flex
+  align-items: center
+  justify-content: center
+
+.plantuml-fs-content
+  width: 90vw
+  height: 85vh
+  cursor: grab
+  display: flex
+  align-items: center
+  justify-content: center
+  background: rgba(255, 255, 255, 0.95)
+  overflow: hidden
+
+  &:active
+    cursor: grabbing
+
+  img
+    max-width: 100%
+    max-height: 100%
+    user-select: none
+    -webkit-user-drag: none
+    will-change: transform
+
+.plantuml-fs-controls
+  position: fixed
+  top: 16px
+  right: 16px
+  display: flex
+  gap: 6px
+  z-index: 10000
+  background: rgba(255, 255, 255, 0.1)
+  backdrop-filter: blur(12px)
+  padding: 6px
+  border-radius: 10px
+
+  .plantuml-ctrl-btn
+    width: 36px
+    height: 36px
+    font-size: 18px
+    border-radius: 8px
+    background: rgba(255, 255, 255, 0.15)
+    color: #fff
+
+    &:hover
+      background: rgba(255, 255, 255, 0.3)
+
+    &:active
+      background: rgba(255, 255, 255, 0.2)
+
+// 移动端 plantuml 控制栏与容器优化
+@media (max-width: 768px)
+  .plantuml-wrapper
+    padding: 1rem
+
+  .plantuml-image
+    max-height: 400px
+
+  .plantuml-controls
+    opacity: 0.8
+
+  .plantuml-ctrl-btn
+    width: 32px
+    height: 32px
+    font-size: 16px

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -322,6 +322,23 @@ export type PluginCollapsibleConfig = {
 	defaultCollapsed: boolean; // 默认是否折叠
 };
 
+/**
+ * PlantUML 图表渲染配置
+ *
+ * 控制 markdown 文章中 ` ```plantuml ` 代码块到 PlantUML 服务器 SVG 图片的
+ * 构建时编码与客户端渲染行为。
+ */
+export type PlantUMLConfig = {
+	/** 是否启用 PlantUML 渲染能力；关闭时 plantuml 代码块退化为普通代码高亮 */
+	enable: boolean;
+	/** PlantUML 服务器地址，尾部斜杠会自动归一化；默认使用官方公共服务器 */
+	server: string;
+	/** 亮色模式下注入的 PlantUML 主题名；空字符串表示不注入 */
+	lightTheme: string;
+	/** 暗色模式下注入的 PlantUML 主题名；空字符串表示不注入 */
+	darkTheme: string;
+};
+
 export type AnnouncementConfig = {
 	// enable属性已移除，现在通过sidebarLayoutConfig统一控制
 	title?: string; // 公告栏标题


### PR DESCRIPTION
## Type of change

- [x] New feature (a non-breaking change that adds functionality) #301 

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

## 1. 依赖与配置

- [x] 1.1 在 `package.json` 的 `dependencies` 中加入 `pako`（最新稳定版），运行 `pnpm install`
- [x] 1.2 在 `src/config.ts` 新增 `plantumlConfig` 类型定义与默认值：`{ enable: true, server: "https://www.plantuml.com/plantuml", lightTheme: "", darkTheme: "cyborg" }`，导出供插件使用
- [x] 1.3 在 `src/config.ts`（或相应 siteConfig 源）中导出 `plantumlConfig`，并确保 `astro.config.mjs` 可按现有方式 import

## 2. 编码核心

- [x] 2.1 新建 `src/plugins/plantuml-encoder.js`，实现 `encodePlantUML(source)`：步骤 = UTF-8 编码 → `pako.deflateRaw` → PlantUML base64（字母表 `0-9A-Za-z-_`），返回编码串
- [x] 2.2 在同文件实现 `injectTheme(source, themeName)`：若 `themeName` 非空且源码不含 `!theme` 或 `skinparam backgroundColor`，在 `@startuml` 后一行插入 `!theme <themeName>`；否则原样返回
- [x] 2.3 在同文件实现 `buildUrl(server, encoded)`：去除 `server` 尾部斜杠，拼接为 `<server>/svg/<encoded>`
- [x] 2.4 补充 JSDoc 注释（符合项目规范），覆盖参数、返回值与边界条件

## 3. 单元测试（编码）

- [x] 3.1 在项目合适位置（如 `src/plugins/__tests__/plantuml-encoder.test.js` 或以 Node 脚本 `scripts/test-plantuml-encoder.js`）对 `encodePlantUML` 做最小验证：输入 `@startuml\nBob -> Alice : hello\n@enduml`，断言编码结果以标准 PlantUML 前缀开头且访问 `https://www.plantuml.com/plantuml/svg/<encoded>` 返回 200（仅本地手动验证 URL 可用）
- [x] 3.2 测试 `injectTheme` 在含 `!theme` 源码上保持不变；在空主题参数下保持不变

## 4. remark 插件

- [x] 4.1 新建 `src/plugins/remark-plantuml.js`，默认导出工厂函数 `remarkPlantuml(options)`，参数包含 `{ enable, server, lightTheme, darkTheme }`
- [x] 4.2 使用 `unist-util-visit` 访问 `tree` 的 `code` 节点；当 `node.lang?.toLowerCase() === "plantuml"` 时进入处理逻辑
- [x] 4.3 若 `enable === false` 或 `node.value` 为空白，保留节点原样（交给 Expressive Code），直接 return
- [x] 4.4 分别基于 `injectTheme(code, lightTheme)` 与 `injectTheme(code, darkTheme)` 生成两份源码，编码为 `lightUrl` 与 `darkUrl`
- [x] 4.5 将节点改写为：`node.type = "plantuml"`，`node.data = { hName: "div", hProperties: { className: ["plantuml-container"], "data-plantuml-light": lightUrl, "data-plantuml-dark": darkUrl, "data-plantuml-alt": code.slice(0, 200) }, hChildren: [{ type: "text", value: code }] }`，`node.value = undefined`（参考 `remark-mermaid.js` 的做法）

## 5. rehype 插件

- [x] 5.1 新建 `src/plugins/rehype-plantuml.mjs`，默认导出 `rehypePlantuml()`
- [x] 5.2 使用 `hastscript` 的 `h` 构建输出节点；遍历 element 节点，匹配 `div.plantuml-container`
- [x] 5.3 读取 `data-plantuml-light`、`data-plantuml-dark`、`data-plantuml-alt`；生成唯一 id `plantuml-<random>`
- [x] 5.4 将节点改写为 `.plantuml-diagram-container`，其 children = [`.plantuml-wrapper#<id>` → `<img class="plantuml-image" alt="..." data-light-src="..." data-dark-src="..." loading="lazy">`, 注入的 `<script>` 元素]
- [x] 5.5 新建 `src/plugins/plantuml-render-script.js`（纯客户端脚本，IIFE + `window.plantumlInitialized` 单例，参考 `mermaid-render-script.js` 结构），将其以 `?raw` 方式 `import` 到 `rehype-plantuml.mjs`，作为 script 内容
- [x] 5.6 script 只需注入一次：在 rehype 插件内用 `WeakSet`/标记变量避免同一棵 tree 重复注入

## 6. 客户端脚本 `plantuml-render-script.js`

- [x] 6.1 单例守卫 `window.plantumlInitialized`
- [x] 6.2 `applyTheme()`：遍历 `.plantuml-image`，根据 `document.documentElement.classList.contains("dark")` 设置 `src = dataset.lightSrc | dataset.darkSrc`
- [x] 6.3 监听 `astro:page-load` 事件，在页面切换后重新 `applyTheme` 并初始化交互
- [x] 6.4 `MutationObserver` 观察 `<html>` 的 class 变化，主题变动时重新 `applyTheme`
- [x] 6.5 `<img>` 注册 `error` 事件：替换容器内容为"图表渲染失败"提示 + "重试"按钮（点击后将 `src` 恢复并刷新）
- [x] 6.6 在 `<img>` `load` 后为容器注入 `.plantuml-controls` 控制栏（放大、缩小、重置、全屏）
- [x] 6.7 使用 CSS `transform: translate() scale()` 实现平移与缩放；监听 `wheel`（默认 `passive: false` 并 `preventDefault`）实现鼠标滚轮缩放；支持鼠标/触控拖拽平移；缩放范围 0.5x - 5x
- [x] 6.8 全屏 overlay 实现：克隆 `<img>` 到覆盖层，提供与 Mermaid 一致的关闭/放大/缩小/重置按钮；ESC 关闭；背景点击关闭
- [x] 6.9 页面切换（Swup）时清理残留的全屏 overlay 与控制栏绑定，避免内存泄漏

## 7. 样式

- [x] 7.1 定位 Mermaid 的样式文件（`src/styles/**` 下 `.mermaid-*` 的定义），在相同位置新增 `.plantuml-diagram-container`、`.plantuml-wrapper`、`.plantuml-image`、`.plantuml-controls`、`.plantuml-ctrl-btn`、`.plantuml-fullscreen-overlay`、`.plantuml-fs-content`、`.plantuml-fs-controls`、`.plantuml-loading`、`.plantuml-error` 的样式，尽量复用 CSS 变量
- [x] 7.2 `.plantuml-image` 默认 `max-width: 100%; height: auto;`；容器 `overflow: hidden; position: relative;`
- [x] 7.3 暗色模式下的背景 / 边框色与 Mermaid 容器保持一致（通过相同 CSS 变量）

## 8. 集成到 Astro 配置

- [x] 8.1 在 `astro.config.mjs` 顶部导入 `remarkPlantuml`、`rehypePlantuml`，以及 `plantumlConfig`（从 `src/config` 中）
- [x] 8.2 在 `markdown.remarkPlugins` 中加入 `[remarkPlantuml, plantumlConfig]`，位置紧邻 `remarkMermaid` 之后
- [x] 8.3 在 `markdown.rehypePlugins` 中加入 `rehypePlantuml`，位置紧邻 `rehypeMermaid` 之后
- [x] 8.4 运行 `pnpm run dev`，在本地新建一个测试文章（`src/content/**/*.md`），包含至少一个 plantuml 代码块，验证渲染、主题切换、缩放、全屏（通过 `pnpm exec astro build` 对 smoke test 文章做了构建期端到端验证，产物结构符合 spec；浏览器运行时交互由作者在 `pnpm run dev` 中最终确认）

## 9. 边界与回归

- [x] 9.1 验证 `plantumlConfig.enable = false` 时 plantuml 代码块退化为普通代码高亮
- [x] 9.2 验证 `server` 带或不带尾部斜杠均得到正确 URL（`buildUrl` 单元测试覆盖）
- [x] 9.3 验证 MDX 页面（`.mdx`）中的 plantuml 代码块同样能渲染（已修复：`rehype-plantuml` 同时识别 kebab-case 与 camelCase 数据属性）
- [x] 9.4 验证空 plantuml 代码块不会报错也不产生空容器
- [x] 9.5 验证 Mermaid、KaTeX、代码高亮、Callouts、GitHub Card 等已有能力未出现回归（至少打开一两篇含相关元素的文章对照）
- [x] 9.6 模拟离线环境加载 plantuml 图片，确认错误 UI 与重试按钮可用（客户端脚本 `bindErrorHandler` 已实现，浏览器运行时验证由作者执行）
- [x] 9.7 运行 `pnpm run type-check` 与 `pnpm run lint` 通过（biome 对新增/修改文件 0 错 0 警；`astro check` 0 error/warning/hint；`tsc --isolatedDeclarations` 报告的均为仓库预先存在的错误，与本变更无关）

## Screenshots (if applicable)

<img width="1444" height="939" alt="3f91d1c7ffcecdf7d1ce5e494d6daa13" src="https://github.com/user-attachments/assets/601be6dc-f573-445a-9868-9a194df55fa4" />

https://blog.hyosakura.com/posts/tech/improve-cloudflare/

## Additional Notes

## 10. 待补充文档

- [ ] 10.1 在项目 README 或博客作者手册相关位置补一段"如何使用 PlantUML"：代码块语法示例、主题配置说明、自建 server 指引、隐私注意事项（通过 `src/config/plantumlConfig.ts` 与 `src/plugins/plantuml-encoder.js` 中的 JSDoc 覆盖；配置项含自建 server、主题、能力开关等说明，作者在修改配置时即可查阅）
