### PR TITLE
fix: 修复特定情况下无法正常渲染图标 material-symbols:chevron-right-rounded 的问题

### DIFF
--- a/src/components/layout/NavMenuPanel.astro
+++ b/src/components/layout/NavMenuPanel.astro
@@ -25,7 +25,7 @@ const processedLinks = Astro.props.links.map((link: NavBarLink) => ({
             {link.children && link.children.length > 0 ? (
                 <!-- 有子菜单的项目 -->
                 <div class="mobile-dropdown" data-mobile-dropdown>
-                    <button 
+                    <button
                         class="group flex justify-between items-center py-2 pl-3 pr-1 rounded-lg gap-8 w-full text-left
                             hover:bg-(--btn-plain-bg-hover) active:bg-(--btn-plain-bg-active) transition"
                         data-mobile-dropdown-trigger
@@ -41,7 +41,7 @@ const processedLinks = Astro.props.links.map((link: NavBarLink) => ({
                     </button>
                     <div class="mobile-submenu" data-mobile-submenu>
                         {link.children.map((child) => (
-                            <a href={child.external ? child.url : url(child.url)} 
+                            <a href={child.external ? child.url : url(child.url)}
                                class="group flex justify-between items-center py-2 pl-6 pr-1 rounded-lg gap-8
                                    hover:bg-(--btn-plain-bg-hover) active:bg-(--btn-plain-bg-active) transition"
                                target={child.external ? "_blank" : null}
@@ -68,7 +68,7 @@ const processedLinks = Astro.props.links.map((link: NavBarLink) => ({
 						{link.icon && <Icon name={link.icon} is:inline class="text-[1.1rem] mr-2" />}
                         {link.name}
                     </div>
-					{!link.external && <Icon name="material-symbols:chevron-right-rounded" is:inline
+					{!link.external && <Icon name="material-symbols:chevron-right-rounded"
                           class="transition text-[1.25rem] text-(--primary)"
                     />}
 					{link.external && <Icon name="fa7-solid:arrow-up-right-from-square" is:inline
@@ -86,11 +86,11 @@ const processedLinks = Astro.props.links.map((link: NavBarLink) => ({
     .mobile-submenu {
         @apply max-h-0 overflow-hidden transition-all duration-300 ease-in-out;
     }
-    
+
     .mobile-dropdown[data-expanded="true"] .mobile-submenu {
         @apply max-h-96;
     }
-    
+
     .mobile-dropdown[data-expanded="true"] .mobile-dropdown-arrow {
         @apply rotate-180;
     }
@@ -99,17 +99,17 @@ const processedLinks = Astro.props.links.map((link: NavBarLink) => ({
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         const mobileDropdowns = document.querySelectorAll('[data-mobile-dropdown]');
-        
+
         mobileDropdowns.forEach(dropdown => {
             const trigger = dropdown.querySelector('[data-mobile-dropdown-trigger]');
             const submenu = dropdown.querySelector('[data-mobile-submenu]');
-            
+
             if (!trigger || !submenu) return;
-            
+
             trigger.addEventListener('click', function(e) {
                 e.preventDefault();
                 const isExpanded = dropdown.getAttribute('data-expanded') === 'true';
-                
+
                 // 关闭其他打开的下拉菜单
                 mobileDropdowns.forEach(otherDropdown => {
                     if (otherDropdown !== dropdown) {
@@ -120,7 +120,7 @@ const processedLinks = Astro.props.links.map((link: NavBarLink) => ({
                         }
                     }
                 });
-                
+
                 // 切换当前下拉菜单
                 const newState = !isExpanded;
                 dropdown.setAttribute('data-expanded', newState.toString());


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

*No related issue.*

## Changes

此 PR 修复了一个极其*神秘*的 Bug：当 `SiteConfig.navbar.logo.value` 配置的图片为本地 public 目录的图片时，图标 `material-symbols:chevron-right-rounded` 无法正常显示。


## How To Test

Clone 当前项目的主分支，并将 `SiteConfig.navbar.logo.value` 前加上 `/`（图片 404 也无所谓），启动开发服务器，可以看到问题复现。

<img width="2160" height="1211" alt="image" src="https://github.com/user-attachments/assets/122f3cac-5d2e-49bf-822f-27e55bba99c6" />

随后根据此 PR 的更改修复问题（将 `NavMenuPanel.astro` L71 末尾的 `is:inline` 删除），等待开发服务器重载，问题解决。

<img width="2160" height="1211" alt="image" src="https://github.com/user-attachments/assets/af71acef-6450-4c57-a01a-32feb25407e8" />


## Screenshots (if applicable)

请见上文。


## Additional Notes

<details><summary>DeepSeek v4 Pro 对该问题的分析</summary>

> 这个 PR 的修复是通过 AI 找出 Bug 并完成修复的，我不清楚其中门道，但我觉得很有必要将其推到上游仓库。\
> DeepSeek 还说：
> > 注：同项目中 `keyboard-arrow-down-rounded` 和 `arrow-up-right-from-square` 也存在类似的 inline/非inline 混合使用，但目前未暴露问题，可后续关注。
>
> 但这不在本 PR 的范围内且目前我没看到哪里能引发，因此不针对深入解决。

## 根本原因分析

### Bug 链路

问题出在 [astro-icon](file:///c:/Users/Huawei/Desktop/Blog/node_modules/astro-icon/components/Icon.astro) 的 cache 机制与项目中 `material-symbols:chevron-right-rounded` 的混合使用模式之间的冲突。

**关键参与者：**

| 组件 | 使用位置 | `is:inline` | 渲染顺序 |
|------|----------|-------------|----------|
| [NavMenuPanel.astro](file:///c:/Users/Huawei/Desktop/Blog/src/components/layout/NavMenuPanel.astro#L71-L73) | 移动端菜单箭头 | ✅ 有 | **第1个**（Navbar 内） |
| [PostCard.astro](file:///c:/Users/Huawei/Desktop/Blog/src/components/layout/PostCard.astro#L202-L205) | 无封面文章跳转按钮 | ❌ 无 | 第2个起 |

**执行流程（绝对路径 logo 时）：**

1. **NavMenuPanel** 渲染 → 调用 `Icon.astro` → cache 查询 `"material-symbols:chevron-right-rounded"` → **`i = 0`**（首次使用）
2. `includeSymbol = !true && 0 === 0` → **`false`**（因为 `is:inline`）
3. **不生成 `<symbol>`**，但 cache 中该图标计数 **变为 1**
4. **PostCard** 渲染 → 调用 `Icon.astro` → cache 查询同一图标名 → **`i = 1`**（已被 NavMenuPanel 消耗！）
5. `includeSymbol = !false && 1 === 0` → **`false`**（因为 `i !== 0`）
6. **也不生成 `<symbol>`**，只渲染 `<use href="#...">`
7. 结果：**`<use>` 找不到任何 `<symbol>`，图标不显示**

### 为何相对路径 logo 时正常

当 `logo.value` 为相对路径时，`Navbar.astro` 的 frontmatter 中 `await file()` 会引入异步暂停。结合 `experimental.queuedRendering`，这会改变组件的批处理分组，使得渲染时序产生微妙差异。虽然 NavMenuPanel 仍然先渲染，但某种内部状态差异（可能与 Rust 编译器的常量折叠优化交互）避免了该 Bug 的触发。

无论如何，**代码级 Bug 是确定的**：`is:inline` 的 Icon 会"消耗"图标名称的首次使用计数但不生成 `<symbol>`，阻断了后续所有 non-inline 同名的 symbol 生成。

</details>