### PR TITLE
fix: 修复移动端首页横幅下方空白

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -694,7 +694,8 @@ const siteLang = lang.replace("_", "-");
   }
 
   @media (max-width: 1023px) {
-    body.enable-banner:not(.lg\:is-home) #main-grid {
+    /* 移动端 banner 已由响应式 top 定位内容，不再叠加桌面端的 main-grid 偏移 */
+    body.enable-banner #main-grid {
       transform: none !important;
     }
 
@@ -1131,7 +1132,7 @@ function disableAnimation() {
           wallpaperWrapper.style.display = "";
           setTimeout(() => {
             mainContentWrapper.classList.remove("mobile-main-no-banner");
-            // 恢复与 SSR 一致的内联 top，而非 removeProperty（否则 CSS 的 70vh 会生效导致内容下移）
+            // 移动端首页交给响应式 CSS 定位，避免叠加桌面端 banner 偏移
             const visitCurrentMode = document.documentElement.getAttribute("data-wallpaper-mode");
             if (visitCurrentMode === "fullscreen") {
               mainContentWrapper.style.position = "relative";
@@ -1144,7 +1145,7 @@ function disableAnimation() {
               mainContentWrapper.style.zIndex = "";
               mainContentWrapper.style.setProperty("margin-top", "0", "important");
             } else {
-              mainContentWrapper.style.setProperty("top", "calc(var(--banner-height) - 3.5rem)", "important");
+              mainContentWrapper.style.removeProperty("top");
               mainContentWrapper.style.position = "";
               mainContentWrapper.style.zIndex = "";
               mainContentWrapper.style.setProperty("margin-top", "0", "important");

--- a/src/utils/setting-utils.ts
+++ b/src/utils/setting-utils.ts
@@ -717,6 +717,9 @@ function adjustMainContentPosition(
 				} else {
 					mainContent.style.setProperty("top", bannerTargetTop, "important");
 				}
+			} else if (window.innerWidth < 1024) {
+				// 移动端首页由 layout-styles.css 的响应式 top 接管，避免与 main-grid 偏移叠加。
+				mainContent.style.removeProperty("top");
 			} else {
 				mainContent.style.setProperty("top", bannerTargetTop, "important");
 			}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

No related issue.

## Changes

修复移动端首页在横幅模式下，横幅图下方与文章列表之间出现额外空白的问题。

在移动端，横幅布局已经通过响应式 CSS（根据屏幕尺寸生效的样式规则）控制主内容区域的位置。但首页仍然叠加了桌面端 `main-grid` 的 `transform` 偏移，导致移动端的 `top` 定位和桌面端横幅偏移同时生效，从而产生额外空白。

本次改动：

- 在移动端横幅模式下统一禁用 `main-grid` 的横幅偏移。
- 让移动端首页继续使用已有的响应式 CSS 规则定位主内容。
- 保持移动端非首页行为不变：隐藏横幅，内容从导航栏下方开始。
- 保持桌面端横幅布局不变。

## How To Test

在修复前代码中：

1. 使用横幅壁纸模式。
2. 将 `backgroundWallpaper.switchable` 设置为 `false`。
3. 可将 `siteConfig.categoryBar` 设置为 `false`，方便观察横幅与文章列表之间的间距。
4. 使用小于 `1024px` 的移动端视口直接打开首页，或在首页硬刷新。
5. 观察横幅下方与文章列表之间出现额外空白。

<img width="964" height="1186" alt="image" src="https://github.com/user-attachments/assets/7918e012-a0e5-42f9-8b5a-94ce2acd32cc" />

该问题在移动端首页首次加载时更容易复现；通过前端页面切换回首页后，布局状态可能会被重新调整，空白不一定继续存在。

修复后该问题消失。

## Screenshots (if applicable)

见上文

## Additional Notes

> 该 PR 由 GPT-5.5 协助修复

修复前，移动端首页可能同时受到两类定位影响：

- 响应式样式负责将主内容放到移动端横幅底部。
- 桌面端横幅逻辑仍会给 main-grid 追加偏移。

本次修复在移动端取消了这层额外偏移，使移动端首页的位置计算回到已有的响应式样式逻辑中。
