### PR TITLE
fix: 修复移动端首页横幅下方空白

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -694,7 +694,7 @@ const siteLang = lang.replace("_", "-");
   }
 
   @media (max-width: 1023px) {
-    body.enable-banner:not(.lg\:is-home) #main-grid {
+    body.enable-banner #main-grid {
       transform: none !important;
     }
 
@@ -993,7 +993,11 @@ function disableAnimation() {
 
       // 桌面端横幅模式：统一用banner高度定位，不改变grid transform
       if (!isMobileForBanner && currentMode === "banner" && mainEl) {
-        mainEl.style.setProperty("top", "calc(var(--banner-height) - 3rem)", "important");
+        if (isHome) {
+          mainEl.style.setProperty("top", "calc(var(--banner-height) - 3rem)");
+        } else {
+          mainEl.style.setProperty("top", "calc(var(--banner-height) - 3rem)", "important");
+        }
         mainEl.style.position = "";
         mainEl.style.zIndex = "";
         mainEl.style.setProperty("margin-top", "0", "important");
@@ -1131,7 +1135,7 @@ function disableAnimation() {
           wallpaperWrapper.style.display = "";
           setTimeout(() => {
             mainContentWrapper.classList.remove("mobile-main-no-banner");
-            // 恢复与 SSR 一致的内联 top，而非 removeProperty（否则 CSS 的 70vh 会生效导致内容下移）
+            // 保留与 SSR 一致的内联 top，切回桌面端时可恢复横幅定位；移动端由断点 CSS 接管具体位置
             const visitCurrentMode = document.documentElement.getAttribute("data-wallpaper-mode");
             if (visitCurrentMode === "fullscreen") {
               mainContentWrapper.style.position = "relative";
@@ -1144,7 +1148,7 @@ function disableAnimation() {
               mainContentWrapper.style.zIndex = "";
               mainContentWrapper.style.setProperty("margin-top", "0", "important");
             } else {
-              mainContentWrapper.style.setProperty("top", "calc(var(--banner-height) - 3.5rem)", "important");
+              mainContentWrapper.style.setProperty("top", "calc(var(--banner-height) - 3.5rem)");
               mainContentWrapper.style.position = "";
               mainContentWrapper.style.zIndex = "";
               mainContentWrapper.style.setProperty("margin-top", "0", "important");
@@ -1176,7 +1180,11 @@ function disableAnimation() {
           }
           // 桌面端横幅模式：统一用banner高度定位，不改变grid transform
           if (visitDesktopMode === "banner") {
-            mainContentWrapper.style.setProperty("top", "calc(var(--banner-height) - 3rem)", "important");
+            if (isHomePage) {
+              mainContentWrapper.style.setProperty("top", "calc(var(--banner-height) - 3rem)");
+            } else {
+              mainContentWrapper.style.setProperty("top", "calc(var(--banner-height) - 3rem)", "important");
+            }
             mainContentWrapper.style.position = "";
             mainContentWrapper.style.zIndex = "";
             mainContentWrapper.style.setProperty("margin-top", "0", "important");
@@ -1262,7 +1270,11 @@ function disableAnimation() {
 
       // 桌面端横幅模式：统一用banner高度定位，不改变grid transform
       if (!isMobileForBanner && currentMode === "banner" && mainEl) {
-        mainEl.style.setProperty("top", "calc(var(--banner-height) - 3rem)", "important");
+        if (isHome) {
+          mainEl.style.setProperty("top", "calc(var(--banner-height) - 3rem)");
+        } else {
+          mainEl.style.setProperty("top", "calc(var(--banner-height) - 3rem)", "important");
+        }
         mainEl.style.position = "";
         mainEl.style.zIndex = "";
         mainEl.style.setProperty("margin-top", "0", "important");

--- a/src/utils/setting-utils.ts
+++ b/src/utils/setting-utils.ts
@@ -718,7 +718,7 @@ function adjustMainContentPosition(
 					mainContent.style.setProperty("top", bannerTargetTop, "important");
 				}
 			} else {
-				mainContent.style.setProperty("top", bannerTargetTop, "important");
+				mainContent.style.setProperty("top", bannerTargetTop);
 			}
 			const bannerGrid = document.getElementById("main-grid");
 			if (bannerGrid) {


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

No related issue.

## Changes

修复首页横幅模式在移动端和响应式切换时的主内容定位问题。

具体调整：

- 移动端横幅模式下，首页的 `#main-grid` 不再保留桌面端的 `translateY` 偏移，避免横幅下方出现额外空白。
- 首页横幅模式写入主内容区 `top` 时不再使用 `!important`，让移动端断点样式可以在窄屏下接管位置。
- 非首页横幅模式仍保留原有 `!important` 定位逻辑，避免影响移动端非首页隐藏横幅后的布局。
- 保留原本通过内联 `top` 恢复桌面端横幅定位的思路，没有改动 `window.onresize`，也没有使用 `removeProperty("top")`。

## How To Test

在修复前代码中：

1. 使用横幅壁纸模式。
2. 将 `backgroundWallpaper.switchable` 设置为 `false`。
3. 可将 `siteConfig.categoryBar` 设置为 `false`，方便观察横幅与文章列表之间的间距。
4. 使用小于 `1024px` 的移动端视口直接打开首页，或在首页硬刷新。
5. 观察横幅下方与文章列表之间出现额外空白。

<img width="964" height="1186" alt="image" src="https://github.com/user-attachments/assets/7918e012-a0e5-42f9-8b5a-94ce2acd32cc" />

该问题在移动端首页首次加载时更容易复现；通过前端页面切换回首页后，布局状态可能会被重新调整，空白不一定继续存在。

修复后该问题消失。

## Screenshots (if applicable)

见上文

## Additional Notes

> 本 PR 由 GPT-5.5 协助修复，因为本人不是很懂 Astro（

已测试过 宽屏进入首页、窄屏进入首页、宽屏切换窄屏、窄屏切换宽屏 均无问题。