### PR TITLE
chore(gitattributes): 统一行尾序列

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.js linguist-language=astro
+* text=auto eol=lf


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please describe): Other change

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

*No related issue.*

## Changes

由于 Git 在 Windows 端会默认启用 core.autocrlf，但 Biome 格式化代码时会将行尾序列统一为 LF，这就会导致在进行 `pnpm lint` 时会产生一大堆幽灵改动。

<img width="1221" height="1316" alt="image" src="https://github.com/user-attachments/assets/76bce200-a42d-4ce0-9ac8-2a918728c630" />

此 PR 向 gitattributes 添加了 `* text=auto eol=lf`，使 git 在签出时保持 LF 行尾序列，保持风格一致的同时避免出现上述的怪异行为。

## How To Test

*Not applicable.*

## Screenshots (if applicable)

*Not applicable.*

## Additional Notes

- [配置 Git 处理行结束符 - GitHub 文档](https://docs.github.com/zh/get-started/git-basics/configuring-git-to-handle-line-endings)