### PR TITLE
fix: 修复home icon颜色显示异常

### DIFF
--- a/src/components/layout/CategoryBar.astro
+++ b/src/components/layout/CategoryBar.astro
@@ -32,7 +32,7 @@ const archiveUrl = url("/archive/");
       data-category-name=""
       aria-label={i18n(I18nKey.home)}
     >
-      <Icon name="material-symbols:home" class="text-lg" />
+      <Icon name="material-symbols:home" is:inline class="text-lg" />
     </a>
     <a
       href={archiveUrl}
@@ -117,6 +117,9 @@ const archiveUrl = url("/archive/");
     color: var(--btn-content);
     background: transparent;
   }
+  .category-pill[data-category-name=""] {
+    color: var(--primary);
+  }
   .category-pill:hover {
     border-color: var(--primary);
     color: var(--primary);
@@ -147,6 +150,10 @@ const archiveUrl = url("/archive/");
     background: var(--primary);
     border-color: var(--primary);
     opacity: 0.9;
+  }
+  .category-pill[data-category-name=""][data-active],
+  .category-pill[data-category-name=""][data-active]:hover {
+    color: white;
   }
 </style>
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

N/A

## Changes

This PR fixes the home icon color behavior in the category bar.

Previously, the home icon did not correctly follow the pill state color:
- In the active state, the icon did not turn white as expected.
- In the inactive state, the icon did not consistently use the theme primary color.

The issue came from two parts:
- The home icon was rendered through the default `astro-icon` symbol/use output path, which did not inherit the expected color behavior in this case.
- The home pill did not have explicit color rules for its inactive and active icon states.

This PR updates the home icon in `src/components/layout/CategoryBar.astro` to use inline SVG rendering with `is:inline`, and adds explicit color rules for the home pill so that:
- the inactive home icon uses `var(--primary)`
- the active home icon uses `white`

The change is intentionally scoped to the home pill only and does not alter the existing behavior of archive or category pills.

## How To Test

1. Start the project locally.
2. Open the home page and check the category bar.
3. Verify that the home pill icon is white when the home page is active.
4. Navigate to a non-home page where the home pill is inactive.
5. Verify that the home pill icon uses the theme primary color.
6. Hover the home pill and confirm the color behavior remains consistent.
7. Confirm that archive and category pills keep their existing styles.

## Screenshots (if applicable)
**old**
<img width="759" height="535" alt="image" src="https://github.com/user-attachments/assets/ac1f08b0-83f8-49fe-bb3b-75fd9b98a216" />

**new**
<img width="919" height="535" alt="image" src="https://github.com/user-attachments/assets/a6c578ac-8c93-4d07-aac6-ce78f1b73f71" />

## Additional Notes

This is a focused fix for a single UI issue and does not introduce behavioral changes outside of the category bar home button.