### PR TITLE
fix: 修复文章封面图被强制裁切

### DIFF
--- a/src/components/common/CoverImage.astro
+++ b/src/components/common/CoverImage.astro
@@ -114,6 +114,14 @@ const sizes = preview
 	: "(max-width: 768px) 100vw, (max-width: 1200px) 90vw, 1200px";
 const quality = preview ? Math.round(configQuality * 0.9) : configQuality;
 
+const getPictureSizeProps = (image: ImageMetadata) => {
+	if (preview) {
+		return { width: 400, height: 300, widths, sizes };
+	}
+	const baseHeight = Math.round(1200 / (image.width / image.height));
+	return { width: 1200, height: baseHeight, widths, sizes };
+};
+
 // 是否显示加载动画
 const showLoading = coverImageConfig.randomCoverImage.showLoading ?? true;
 
@@ -159,15 +167,12 @@ const remoteReferrerPolicy =
 				alt="Fallback cover"
 				class={imageClass}
 				style={imageStyle}
-				width={preview ? 400 : 1200}
-				height={preview ? 300 : 800}
 				loading="lazy"
 				formats={formats}
 				fallbackFormat={fallbackFormat}
 				quality={quality}
-				widths={widths}
-				sizes={sizes}
 				layout={layout}
+				{...getPictureSizeProps(fallbackImg)}
 			/>
 		</div>
 	)}
@@ -192,15 +197,12 @@ const remoteReferrerPolicy =
 			alt={alt || ""}
 			class={imageClass}
 			style={imageStyle}
-			width={preview ? 400 : 1200}
-			height={preview ? 300 : 800}
 			loading={loading}
 			formats={formats}
 			fallbackFormat={fallbackFormat}
 			quality={quality}
-			widths={widths}
-			sizes={sizes}
 			layout={layout}
+			{...getPictureSizeProps(img)}
 			data-cover-img
 		/>
 	)}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

No related issue.

## Changes

修复了封面图片被强制裁切到固定 1200×800 比例的问题。

新增 getPictureSizeProps 函数，根据图片实际宽高比动态计算输出尺寸：
- 预览模式：固定 400×300
- 非预览模式：宽度固定 1200，高度按原图比例计算（Math.round(1200 / (width / height))）

## How To Test

1. 使用不同宽高比的封面图片（如 16:9、4:3、1:1）发布文章
2. 检查首页卡片和文章详情页的封面图是否保持原始比例，未被拉伸或裁切变形

## Screenshots (if applicable)

修复前：

<img width="1240" height="931" alt="image" src="https://github.com/user-attachments/assets/dde5050f-25c9-4c7d-b590-78743984242d" />

修复后：

<img width="1229" height="806" alt="image" src="https://github.com/user-attachments/assets/66e50ee4-9468-4d28-a755-4cfad518e73e" />


## Additional Notes

无
