### PR TITLE
fix: 修复全部标签页面标签未适配深色模式的问题

### DIFF
--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -57,7 +57,7 @@ const getDepth = (count: number) => {
     .tag-item {
         /* color-mix 将主题色按深度比例混入背景 */
         background: color-mix(in oklch, var(--primary) calc(var(--tag-depth) * 35%), var(--page-bg));
-        color: var(--text-content);
+        color: var(--primary);
     }
     .tag-item:hover {
         background: color-mix(in oklch, var(--primary) calc(var(--tag-depth) * 35% + 15%), var(--page-bg));
@@ -65,5 +65,6 @@ const getDepth = (count: number) => {
     .tag-count {
         /* 计数徽章比主体稍深一点 */
         background: color-mix(in oklch, var(--primary) calc(var(--tag-depth) * 35% + 10%), var(--page-bg));
+		color: var(--primary);
     }
 </style>


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

*No related issue.*

## Changes

修复了全部标签页面未适配深色模式的问题。\
此外，标签内文字现将会跟随主题色。

## How To Test

修复前: https://firefly.cuteleaf.cn/tags/
修复后: 拉取 / 下载本 PR 分支，`pnpm install` & `pnpm dev`，访问 http://localhost:4321/tags/

## Screenshots (if applicable)

### Before

<img width="1079" height="448" alt="image" src="https://github.com/user-attachments/assets/15416888-4048-4a06-9a47-68404a7ddf58" />

<img width="1089" height="454" alt="image" src="https://github.com/user-attachments/assets/3fc7066c-bd4e-4c88-ada8-c1189a47a35c" />

### After

<img width="1085" height="525" alt="image" src="https://github.com/user-attachments/assets/b026d094-260e-488a-a176-0e21f84310ab" />

<img width="1077" height="543" alt="image" src="https://github.com/user-attachments/assets/a1f476d8-4c94-4df3-92ec-c309f03e7d86" />

## Additional Notes

*Nothing.*
