### PR TITLE
fix(LightDarkSwitch): 修复切换颜色模式后导航栏图标未刷新的问题

### DIFF
--- a/src/components/controls/LightDarkSwitch.svelte
+++ b/src/components/controls/LightDarkSwitch.svelte
@@ -30,6 +30,7 @@ let displayedMode: LIGHT_DARK_MODE = $state(LIGHT_MODE); // 显示的实际主�
 function switchScheme(newMode: LIGHT_DARK_MODE) {
 	mode = newMode;
 	setTheme(newMode);
+	updateDisplayedMode();
 }
 
 // 更新显示的主题（用于显示当前实际主题）


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

*No related issue.*

## Changes

修复了切换颜色模式后导航栏图标未刷新的问题。

## How To Test

通过导航栏切换颜色模式查看效果。

## Screenshots (if applicable)

### Before

<img width="401" height="342" alt="image" src="https://github.com/user-attachments/assets/35cfa307-efd7-48e2-a037-4121127ea244" />

### Now

<img width="338" height="303" alt="image" src="https://github.com/user-attachments/assets/cb4133f8-b056-408b-8696-4df8c6cbc52e" />

## Additional Notes

*Noting.*