### PR TITLE
fix(MusicPlayer): 修复打开播放列表时未刷新歌词开启状态的问题

### DIFF
--- a/src/components/features/MusicPlayer.astro
+++ b/src/components/features/MusicPlayer.astro
@@ -724,6 +724,8 @@ const widgetId =
             ui.lrcDrawer.classList.add('opacity-0');
             ui.btnLrc.classList.remove('text-(--primary)');
             ui.btnLrc.classList.add('text-neutral-400');
+            ui.iconLrcOn.classList.add('hidden');
+            ui.iconLrcOff.classList.remove('hidden');
 
             ui.playlistDrawer.style.gridTemplateRows = '1fr';
             ui.playlistDrawer.classList.add('opacity-100');


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

*No related issue.*

## Changes

修复了导航栏音乐播放器开启歌词后再打开播放列表时字幕开启状态未刷新的问题。

## How To Test

打开导航栏音乐播放器，打开歌词，再打开播放列表以查看修复效果。

## Screenshots (if applicable)

### Before

<img width="601" height="565" alt="image" src="https://github.com/user-attachments/assets/febc622d-0aca-4cc9-a376-023011e65fcd" />

### Now

<img width="533" height="572" alt="image" src="https://github.com/user-attachments/assets/d4950d43-9f84-483f-a789-a7295dd3ff13" />

## Additional Notes

*Noting.*