### PR TITLE
feat(PostCard): 首页文章列表支持显示文章更新日期

### DIFF
--- a/src/components/layout/PostCard.astro
+++ b/src/components/layout/PostCard.astro
@@ -32,6 +32,7 @@ const {
 	title,
 	url,
 	published,
+	updated,
 	tags,
 	category,
 	image,
@@ -109,6 +110,7 @@ const descriptionText = description || remarkPluginFrontmatter.excerpt || "";
     <!-- metadata -->
     <PostMetadata
       published={published}
+      updated={updated}
       tags={tags}
       showTags={false}
       category={category || undefined}


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

*No related issue.*

## Changes

首页文章列表支持显示文章更新日期。

## How To Test

随便给一篇文章添加晚于文章创建日期的更新日期查看实现效果。

## Screenshots (if applicable)

### Before

<img width="1049" height="366" alt="image" src="https://github.com/user-attachments/assets/250e8674-3403-4065-8a35-fa3f0e5c5e1a" />

### Now (Preview)

<img width="1090" height="373" alt="image" src="https://github.com/user-attachments/assets/31caa459-ff38-48b4-ad06-28adc3af9e51" />

## Additional Notes

这似乎是一个 Bug，实际上 PostCard 有渲染逻辑，只是因为缺少传参。