### PR TITLE
fix(ArchivePanel): 修复归档页默认折叠年份按钮图标显示异常的问题

### DIFF
--- a/src/components/controls/ArchivePanel.svelte
+++ b/src/components/controls/ArchivePanel.svelte
@@ -237,7 +237,7 @@ onMount(async () => {
 				<div class="w-[70%] md:w-[80%] transition text-left text-50 flex items-center gap-2
 				            group-hover/yr:text-(--primary)">
 					{group.posts.length} {i18n(group.posts.length === 1 ? I18nKey.postCount : I18nKey.postsCount)}
-					<span class="archive-arrow">
+					<span class="archive-arrow" style={collapsedYears.has(group.year) ? 'transform: rotate(-90deg)' : ''}>
 						<svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
 							<path d="M6 9l6 6 6-6" stroke-linecap="round" stroke-linejoin="round"/>
 						</svg>


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Changes

修复了归档页默认被折叠年份的按钮的图标 默认被折叠时也显示为展开状态的问题

## Screenshots (if applicable)

### Before (Preview)

<img width="453" height="354" alt="image" src="https://github.com/user-attachments/assets/db9b968b-878f-45ea-9453-f7a2715297c3" />

### Now (Preview)

<img width="458" height="343" alt="image" src="https://github.com/user-attachments/assets/a9288ba3-7bb5-444f-9a0f-0e4afc50f8f9" />