### PR TITLE
feat: Expressive Code 代码块折叠渐变样式适配亮暗色

### DIFF
--- a/src/styles/expressive-code.css
+++ b/src/styles/expressive-code.css
@@ -34,6 +34,25 @@
   }
 }
 
+/* 折叠渐变样式适配亮暗色 */
+/* 亮色模式：白色渐变 */
+.ec-collapse__gradient {
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 1) 100%
+  ) !important;
+}
+
+/* 暗色模式：黑色渐变 */
+.dark .ec-collapse__gradient {
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) 0%,
+    rgba(0, 0, 0, 1) 100%
+  ) !important;
+}
+
 /* 透明模式下的代码块样式 */
 /*
  * 仅处理外层容器背景，避免清空 ANSI token 的背景色。


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->

Expressive Code 代码块的折叠渐变遮罩默认是从透明过度到黑色，在亮色模式下会显得很突兀

这里将遮罩改为亮色模式下从透明到白色，暗色模式下从透明到黑色，以适配亮色、暗色主题

## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->

### 修改前
<img width="1382" height="495" alt="image" src="https://github.com/user-attachments/assets/7ecb53cf-c2c2-406a-9c2e-5ab18a8a8ed8" />
<img width="1385" height="500" alt="image" src="https://github.com/user-attachments/assets/3d3eed4f-3ac9-4771-aed0-17511f63fed2" />

### 修改后
<img width="1389" height="513" alt="亮色" src="https://github.com/user-attachments/assets/9da2bab3-7a60-4e8e-81ed-cea989b07c66" />
<img width="1391" height="538" alt="暗色" src="https://github.com/user-attachments/assets/5f025e8e-5876-423a-b2fb-a5df4bbfe6fe" />

## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
