### PR TITLE
refactor: remove dead banner fallback code in Layout.astro

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -59,10 +59,6 @@ const navbarTransparentMode =
 const shouldShowTopHighlight =
 	navbarTransparentMode === "full" || navbarTransparentMode === "semifull";
 
-if (!banner || typeof banner !== "string" || banner.trim() === "") {
-	banner = getDefaultBackground();
-}
-
 // TODO don't use post cover as banner for now
 banner = getDefaultBackground();
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (please describe): 删除死代码

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Changes

删除了 `banner` 的条件判断回退逻辑。由于后续存在对 `banner` 的无条件赋值（`banner = getDefaultBackground()`），该条件判断从未实际生效，属于死代码。

## How To Test

无需额外测试，行为与删除前完全一致。
