### PR TITLE
feat: 「最后活动」改为综合 published 与 updated 的最大值

### DIFF
--- a/src/components/widget/SiteStats.astro
+++ b/src/components/widget/SiteStats.astro
@@ -56,15 +56,20 @@ function formatNumber(num: number): string {
 	return num.toLocaleString();
 }
 
-// 获取最新文章日期（用于客户端计算）
-const latestPost = posts.reduce((latest, post) => {
-	if (!latest) return post;
-	return post.data.published > latest.data.published ? post : latest;
-}, posts[0]);
+// 获取「最后活动」时间：取每篇文章 published 与 updated 中较新的那个，再从全站所有文章里取最大值。这样新发文章和修改老文章都会刷新该字段。
+const getActivityDate = (post: (typeof posts)[number]): Date => {
+	const { published, updated } = post.data;
+	if (updated && updated > published) return updated;
+	return published;
+};
 
-const lastPostDate = latestPost
-	? latestPost.data.published.toISOString()
-	: null;
+const lastActivityDate = posts.reduce<Date | null>((latest, post) => {
+	const current = getActivityDate(post);
+	if (!latest || current > latest) return current;
+	return latest;
+}, null);
+
+const lastPostDate = lastActivityDate ? lastActivityDate.toISOString() : null;
 
 const todayText = i18n(I18nKey.today);
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [ ] I have read the [**[CONTRIBUTING](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md)**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Changes

「最后活动」时间的计算逻辑由"取最新 `published`"改为"取每篇文章 `published` 与 `updated` 中较新的那个，再取全站最大值"。这样修改已发布文章时也会刷新该字段。

同时修复了 `posts` 为空时 `reduce` 可能崩溃的边界情况。

## How To Test

1. 修改一篇较早发布的文章，为其添加 `updated` 字段并设为最新日期。
2. 确认「最后活动」时间显示为该 `updated` 值，而非最新 `published` 日期。
