### PR TITLE
fix: 生产构建中保留 console.warn / console.error

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -278,8 +278,10 @@ export default defineConfig({
 			minify: "esbuild",
 			esbuildOptions: {
 				minify: true,
-				// 移除 console.log 和 debugger
-				drop: ["console", "debugger"],
+				// 删除 debugger 语句；console.log / console.debug 无副作用，未使用返回值时会被 dead code elimination 移除，
+				// console.warn / console.error 保留，确保生产环境出错时仍有日志可查
+				drop: ["debugger"],
+				pure: ["console.log", "console.debug"],
 			},
 			rollupOptions: {
 				onwarn(warning, warn) {
@@ -300,3 +302,4 @@ export default defineConfig({
 		},
 	},
 });
+


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [ ] I have read the [**[CONTRIBUTING](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md)**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Changes

`drop: ["console"]` 会删除所有 `console.*` 调用，与注释意图（仅删除 `console.log`）不符。改用 `pure` 选项精确控制：

- `drop: ["debugger"]` — 只删除 `debugger` 语句
- `pure: ["console.log", "console.debug"]` — 标记为无副作用，由 dead code elimination 移除
- `console.warn` / `console.error` 保留，生产环境出错时仍有日志可查

## How To Test

1. 在源码中分别调用 `console.log`、`console.warn`、`console.error`。
2. 执行生产构建，检查产物。
3. 确认 `console.log` 已被移除，`console.warn` 和 `console.error` 保留。

## Additional Notes

依赖库内部的 `console.warn` / `console.error` 同样不再被删除，对第三方库的错误可观测性有正面影响。
