### PR TITLE
feat(ArchivePanel): 支持控制归档页自动折叠默认行为

### DIFF
--- a/src/components/controls/ArchivePanel.svelte
+++ b/src/components/controls/ArchivePanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { onMount } from "svelte";
 
+import { siteConfig } from "@/config";
 import I18nKey from "@/i18n/i18nKey";
 import { i18n } from "@/i18n/translation";
 import { getPostUrlBySlug } from "@/utils/url-utils";
@@ -167,8 +168,7 @@ onMount(async () => {
 
 	groups = groupedPostsArray;
 
-	// 默认只展开最近一年，其他年份折叠
-	if (groupedPostsArray.length > 1) {
+	if (siteConfig.foldArticle !== false && groupedPostsArray.length > 1) {
 		collapsedYears = new Set(groupedPostsArray.slice(1).map((g) => g.year));
 	}
 

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -114,6 +114,9 @@ export const siteConfig: SiteConfig = {
 	// 分类导航栏开关，在首页和归档页顶部显示分类快捷导航
 	categoryBar: true,
 
+	// 是否折叠非最新年份文章，禁用后默认展开全部年份
+	foldArticle: true,
+
 	// 文章列表布局配置
 	postListLayout: {
 		// 默认布局模式："list" 列表模式（单列布局），"grid" 网格模式（多列布局）

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -114,7 +114,7 @@ export const siteConfig: SiteConfig = {
 	// 分类导航栏开关，在首页和归档页顶部显示分类快捷导航
 	categoryBar: true,
 
-	// 是否折叠非最新年份文章，禁用后默认展开全部年份
+	// 归档页是否折叠非最新年份文章，禁用后默认展开全部年份
 	foldArticle: true,
 
 	// 文章列表布局配置

--- a/src/types/siteConfig.ts
+++ b/src/types/siteConfig.ts
@@ -89,6 +89,9 @@ export type SiteConfig = {
 	// 分类导航栏开关
 	categoryBar?: boolean;
 
+	// 是否折叠非最新年份文章
+	foldArticle?: boolean;
+
 	// 文章列表布局配置
 	postListLayout: {
 		defaultMode: "list" | "grid"; // 默认布局模式：list=列表模式，grid=网格模式

--- a/src/types/siteConfig.ts
+++ b/src/types/siteConfig.ts
@@ -89,7 +89,7 @@ export type SiteConfig = {
 	// 分类导航栏开关
 	categoryBar?: boolean;
 
-	// 是否折叠非最新年份文章
+	// 归档页是否折叠非最新年份文章
 	foldArticle?: boolean;
 
 	// 文章列表布局配置


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Changes

新增配置 `SiteConfig.foldArticle`，用于控制文章归档页中非最新年份文章是否自动折叠。\
默认为 `true`，与当前行为一致。

## How To Test

在 `src\config\siteConfig.ts` 开关 `foldArticle` 配置并访问 `/archive/` 页查看效果。

## Additional Notes

博客可能一年到头写不了几篇文章，文章总数不多（比如我），自动折叠了可能不方便；或者说我就是希望不折叠，能出个配置控制一下感觉还是有用的。