### PR TITLE
feat: 修改导航栏的菜单选项逻辑为自动判断

### DIFF
--- a/src/components/layout/Navbar.astro
+++ b/src/components/layout/Navbar.astro
@@ -56,7 +56,29 @@ const allowLayoutSwitch = siteConfig.postListLayout.allowSwitch;
 const hasDisplaySettings =
 	showThemeColor || isWallpaperSwitchable || allowLayoutSwitch;
 
-let links: NavBarLink[] = navBarConfig.links;
+// 根据 siteConfig.pages 过滤导航栏链接
+const pages = siteConfig.pages;
+
+function isPageEnabled(link: NavBarLink): boolean {
+	if (!link.pageKey) return true;
+	return pages[link.pageKey as keyof typeof pages] !== false;
+}
+
+function filterLinks(link: NavBarLink): NavBarLink | null {
+	if (!link.children) {
+		return isPageEnabled(link) ? link : null;
+	}
+
+	const filteredChildren = link.children.filter(isPageEnabled);
+
+	if (filteredChildren.length === 0) return null;
+	if (filteredChildren.length === 1) return filteredChildren[0];
+	return { ...link, children: filteredChildren };
+}
+
+let links: NavBarLink[] = navBarConfig.links
+	.map(filterLinks)
+	.filter((link): link is NavBarLink => link !== null);
 
 // 处理导航栏 Logo 图片
 const logoValue = siteConfig.navbar.logo?.value || "";

--- a/src/config/navBarConfig.ts
+++ b/src/config/navBarConfig.ts
@@ -4,31 +4,20 @@ import {
 	type NavBarSearchConfig,
 	NavBarSearchMethod,
 } from "../types/navBarConfig";
-import { siteConfig } from "./siteConfig";
 
+// ============================================================================
+// 导航栏配置 - 根据顺序动态生成导航栏链接
+// NavBar Configuration - Dynamically generate navigation bar links based on order
+// ============================================================================
 const getDynamicNavBarConfig = (): NavBarConfig => {
-	const pages = siteConfig.pages;
+	// 基础导航栏链接
+	const links: NavBarLink[] = [
+		// 主页
+		LinkPresets.Home,
+	];
 
-	function isEnabled(link: NavBarLink): boolean {
-		if (!link.pageKey) return true;
-		return pages[link.pageKey as keyof typeof pages] !== false;
-	}
-
-	function processLink(link: NavBarLink): NavBarLink | null {
-		if (!link.children) {
-			return isEnabled(link) ? link : null;
-		}
-
-		const filteredChildren = link.children.filter(isEnabled);
-
-		if (filteredChildren.length === 0) return null;
-		if (filteredChildren.length === 1) return filteredChildren[0];
-		return { ...link, children: filteredChildren };
-	}
-
-	const rawLinks: NavBarLink[] = [LinkPresets.Home];
-
-	rawLinks.push({
+	// 文章及其子菜单
+	links.push({
 		name: "文章",
 		url: "#",
 		icon: "material-symbols:article",
@@ -37,18 +26,21 @@ const getDynamicNavBarConfig = (): NavBarConfig => {
 			LinkPresets.Archive,
 
 			// 分类
-LinkPresets.Categories,
+			LinkPresets.Categories,
 
 			// 标签
-LinkPresets.Tags,
-],
+			LinkPresets.Tags,
+		],
 	});
 
-	rawLinks.push(LinkPresets.Friends);
+	// 友链
+	links.push(LinkPresets.Friends);
 
-	rawLinks.push(LinkPresets.Guestbook);
+	// 留言板
+	links.push(LinkPresets.Guestbook);
 
-	rawLinks.push({
+	// 我的及其子菜单
+	links.push({
 		name: "我的",
 		url: "#",
 		icon: "material-symbols:person",
@@ -61,7 +53,8 @@ LinkPresets.Tags,
 		],
 	});
 
-	rawLinks.push({
+	// 关于及其子菜单
+	links.push({
 		name: "关于",
 		url: "#",
 		icon: "material-symbols:info",
@@ -74,10 +67,12 @@ LinkPresets.Tags,
 		],
 	});
 
-	rawLinks.push({
+	// 自定义导航栏链接
+	links.push({
 		name: "链接",
 		url: "#",
 		icon: "material-symbols:link",
+		// 子菜单
 		children: [
 			{
 				name: "GitHub",
@@ -105,17 +100,14 @@ LinkPresets.Tags,
 			},
 		],
 	});
+
 	// 文档链接
-	// rawLinks.push({
+	// links.push({
 	// 	name: "文档",
 	// 	url: "https://docs-firefly.cuteleaf.cn",
 	// 	external: true,
 	// 	icon: "material-symbols:docs",
 	// });
-
-	const links: NavBarLink[] = rawLinks
-		.map(processLink)
-		.filter((link): link is NavBarLink => link !== null);
 
 	return { links } as NavBarConfig;
 };

--- a/src/config/navBarConfig.ts
+++ b/src/config/navBarConfig.ts
@@ -4,20 +4,31 @@ import {
 	type NavBarSearchConfig,
 	NavBarSearchMethod,
 } from "../types/navBarConfig";
+import { siteConfig } from "./siteConfig";
 
-// ============================================================================
-// 导航栏配置 - 根据顺序动态生成导航栏链接
-// NavBar Configuration - Dynamically generate navigation bar links based on order
-// ============================================================================
 const getDynamicNavBarConfig = (): NavBarConfig => {
-	// 基础导航栏链接
-	const links: NavBarLink[] = [
-		// 主页
-		LinkPresets.Home,
-	];
+	const pages = siteConfig.pages;
 
-	// 文章及其子菜单
-	links.push({
+	function isEnabled(link: NavBarLink): boolean {
+		if (!link.pageKey) return true;
+		return pages[link.pageKey as keyof typeof pages] !== false;
+	}
+
+	function processLink(link: NavBarLink): NavBarLink | null {
+		if (!link.children) {
+			return isEnabled(link) ? link : null;
+		}
+
+		const filteredChildren = link.children.filter(isEnabled);
+
+		if (filteredChildren.length === 0) return null;
+		if (filteredChildren.length === 1) return filteredChildren[0];
+		return { ...link, children: filteredChildren };
+	}
+
+	const rawLinks: NavBarLink[] = [LinkPresets.Home];
+
+	rawLinks.push({
 		name: "文章",
 		url: "#",
 		icon: "material-symbols:article",
@@ -26,21 +37,18 @@ const getDynamicNavBarConfig = (): NavBarConfig => {
 			LinkPresets.Archive,
 
 			// 分类
-			LinkPresets.Categories,
+LinkPresets.Categories,
 
 			// 标签
-			LinkPresets.Tags,
-		],
+LinkPresets.Tags,
+],
 	});
 
-	// 友链
-	links.push(LinkPresets.Friends);
+	rawLinks.push(LinkPresets.Friends);
 
-	// 留言板
-	links.push(LinkPresets.Guestbook);
+	rawLinks.push(LinkPresets.Guestbook);
 
-	// 我的及其子菜单
-	links.push({
+	rawLinks.push({
 		name: "我的",
 		url: "#",
 		icon: "material-symbols:person",
@@ -53,8 +61,7 @@ const getDynamicNavBarConfig = (): NavBarConfig => {
 		],
 	});
 
-	// 关于及其子菜单
-	links.push({
+	rawLinks.push({
 		name: "关于",
 		url: "#",
 		icon: "material-symbols:info",
@@ -67,12 +74,10 @@ const getDynamicNavBarConfig = (): NavBarConfig => {
 		],
 	});
 
-	// 自定义导航栏链接
-	links.push({
+	rawLinks.push({
 		name: "链接",
 		url: "#",
 		icon: "material-symbols:link",
-		// 子菜单
 		children: [
 			{
 				name: "GitHub",
@@ -100,14 +105,17 @@ const getDynamicNavBarConfig = (): NavBarConfig => {
 			},
 		],
 	});
-
 	// 文档链接
-	// links.push({
+	// rawLinks.push({
 	// 	name: "文档",
 	// 	url: "https://docs-firefly.cuteleaf.cn",
 	// 	external: true,
 	// 	icon: "material-symbols:docs",
 	// });
+
+	const links: NavBarLink[] = rawLinks
+		.map(processLink)
+		.filter((link): link is NavBarLink => link !== null);
 
 	return { links } as NavBarConfig;
 };
@@ -146,16 +154,19 @@ export const LinkPresets: Record<string, NavBarLink> = {
 		name: "友链",
 		url: "/friends/",
 		icon: "material-symbols:group",
+		pageKey: "friends",
 	},
 	Sponsor: {
 		name: "打赏",
 		url: "/sponsor/",
 		icon: "material-symbols:favorite",
+		pageKey: "sponsor",
 	},
 	Guestbook: {
 		name: "留言",
 		url: "/guestbook/",
 		icon: "material-symbols:chat",
+		pageKey: "guestbook",
 	},
 	About: {
 		name: "关于我",
@@ -166,11 +177,13 @@ export const LinkPresets: Record<string, NavBarLink> = {
 		name: "番组计划",
 		url: "/bangumi/",
 		icon: "material-symbols:movie",
+		pageKey: "bangumi",
 	},
 	Gallery: {
 		name: "相册",
 		url: "/gallery/",
 		icon: "material-symbols:photo-library",
+		pageKey: "gallery",
 	},
 };
 

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -96,8 +96,7 @@ export const siteConfig: SiteConfig = {
 	// 示例："Asia/Shanghai", "UTC", 如果为空，则按照构建服务器的时区进行时区转换
 	timezone: "Asia/Shanghai",
 
-	// 页面开关配置 - 控制特定页面的访问权限，设为false会返回404
-	// 关闭后请前往src/config/navBarConfig.ts中手动移除对应页面的导航栏链接
+	// 页面开关配置 - 控制特定页面的访问权限，设为false会返回404并自动隐藏对应的导航栏菜单项
 	pages: {
 		// 友链页面开关
 		friends: true,

--- a/src/types/navBarConfig.ts
+++ b/src/types/navBarConfig.ts
@@ -4,6 +4,7 @@ export type NavBarLink = {
 	external?: boolean;
 	icon?: string; // 菜单项图标
 	children?: NavBarLink[]; // 支持子菜单
+	pageKey?: string;
 };
 
 export enum NavBarSearchMethod {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

N/A


## Changes

- 将之前导航栏手动开关修改为自动判断
- 只需要改 `siteConfig.pages` 的开关，NavBar 自动跟随
- 没有 `pageKey` 的菜单项始终显示，不影响最基本的菜单选项
- 子项被过滤后，如果父项只剩一个子项，可以简化为直接显示该子项（或保持为子菜单）；如果全部子项被过滤，父项自动隐藏

## How To Test

- 在 `siteConfig.pages` 内修改和调整页面的开关，将含有多个子项的相关菜单关闭其中一个子项，刷新页面，将不含子项的菜单状态关闭，刷新页面


## Screenshots (if applicable)

#### 正常状态
<img width="2357" height="113" alt="image" src="https://github.com/user-attachments/assets/fe6115c8-dbb6-41b1-ac81-b307669e17b1" />

#### 关闭其中一个子项（我的-相册）
<img width="2366" height="117" alt="image" src="https://github.com/user-attachments/assets/5dd84b3f-c28e-43a4-b872-a77365f5f607" />

#### 关闭无子项的菜单项目 （打赏页面）
<img width="2373" height="112" alt="image" src="https://github.com/user-attachments/assets/8f8c238a-ec6d-4bb8-9d8a-78fb6474e774" />

#### 关闭之后页面可用性测试
<img width="2361" height="1667" alt="image" src="https://github.com/user-attachments/assets/7dc0e5a6-e261-4872-9c77-52e54ff46b37" />




## Additional Notes

> 修改 `getDynamicNavBarConfig()` 函数：
> 
> 引入 `siteConfig`
> 给 `NavBarLink` 类型新增可选的 `pageKey` 字段，用于关联 `siteConfig.pages` 的状态
> 在构建 links 时，根据 `siteConfig.pages` 过滤子菜单项
> 如果一个父菜单的所有子菜单项都被关闭，则整个父菜单项也隐藏
> 给 `LinkPresets` 的每个预设添加 `pageKey` 属性

~~部分代码由于格式化和编辑器问题可能没有正确的缩进~~
~~部分注释内容在编写的时候未添加，需要添加一下~~
