### PR TITLE
Add script to quarantine posts with missing images

### DIFF
--- a/scripts/quarantine-bad-posts.mjs
+++ b/scripts/quarantine-bad-posts.mjs
@@ -1,0 +1,71 @@
+/**
+ * 隔离引用了不存在图片的文章
+ * 把这些文章移到 src/content/posts/_quarantine/
+ * Astro 不会构建 _quarantine 里的文章
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import matter from 'gray-matter';
+
+const POSTS_DIR = 'src/content/posts';
+const QUARANTINE_DIR = 'src/content/_quarantine';
+
+if (!fs.existsSync(QUARANTINE_DIR)) {
+  fs.mkdirSync(QUARANTINE_DIR, { recursive: true });
+}
+
+function walk(dir) {
+  return fs.readdirSync(dir).flatMap(f => {
+    const p = path.join(dir, f);
+    return fs.statSync(p).isDirectory()
+      ? walk(p)
+      : f === 'index.md' ? [p] : [];
+  });
+}
+
+function hasMissingImage(file) {
+  const raw = fs.readFileSync(file, 'utf8');
+  const { data, content } = matter(raw);
+
+  const images = new Set();
+
+  // frontmatter 里的 image
+  if (typeof data.image === 'string') {
+    images.add(data.image);
+  }
+
+  // markdown 里的 ![alt](path)
+  const mdImages = [...content.matchAll(/!\[.*?\]\((.+?)\)/g)]
+    .map(m => m[1])
+    .filter(p => !p.startsWith('http'));
+
+  mdImages.forEach(p => images.add(p));
+
+  return [...images].some(img => {
+    const abs = img.startsWith('/')
+      ? path.join('public', img)
+      : path.resolve(path.dirname(file), img);
+
+    return !fs.existsSync(abs);
+  });
+}
+
+function main() {
+  const files = walk(POSTS_DIR);
+  let moved = 0;
+
+  for (const file of files) {
+    if (hasMissingImage(file)) {
+      const target = file.replace(POSTS_DIR, QUARANTINE_DIR);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.renameSync(file, target);
+      console.log(`🚫 Quarantined: ${file}`);
+      moved++;
+    }
+  }
+
+  console.log(`\n✅ Done. Quarantined ${moved} broken posts.`);
+}
+
+main();


### PR DESCRIPTION
This script checks for posts with missing images and moves them to a quarantine directory to prevent them from being built by Astro.

## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [ ] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [ ] I have checked to ensure that this Pull Request is not for personal changes.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->


## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->
