### PR TITLE
feat: 导航栏图标支持填写URL图标

### DIFF
--- a/src/components/layout/DropdownMenu.astro
+++ b/src/components/layout/DropdownMenu.astro
@@ -20,6 +20,17 @@ if (!link) {
 const processedLink = link;
 
 const hasChildren = processedLink.children && processedLink.children.length > 0;
+
+// 判断图标是否为 URL（支持 iconUrl 字段或以 http/https/相对路径开头的 icon）
+function getIconInfo(icon?: string, iconUrl?: string): { isUrl: boolean; src: string } | null {
+	if (iconUrl) return { isUrl: true, src: iconUrl };
+	if (!icon) return null;
+	if (icon.startsWith("http://") || icon.startsWith("https://") || icon.startsWith("//") || icon.startsWith("/")) {
+		return { isUrl: true, src: icon };
+	}
+	return { isUrl: false, src: icon };
+}
+const linkIconInfo = getIconInfo(processedLink.icon, processedLink.iconurl);
 ---
 
 <div class:list={["dropdown-container", className]} data-dropdown>
@@ -31,27 +42,38 @@ const hasChildren = processedLink.children && processedLink.children.length > 0;
 			data-dropdown-trigger
 		>
 			<div class="flex items-center gap-1.5">
-				{processedLink.icon && <Icon is:inline name={processedLink.icon} class="text-[1.1rem] mr-1.5 navbar-icon" />}
+				{linkIconInfo && (
+					linkIconInfo.isUrl
+						? <img src={linkIconInfo.src} alt="" class="text-[1.1rem] mr-1.5 navbar-icon w-[1.1rem] h-[1.1rem]" />
+						: <Icon is:inline name={linkIconInfo.src} class="text-[1.1rem] mr-1.5 navbar-icon" />
+				)}
 				{processedLink.name}
 			</div>
 			<Icon is:inline name="material-symbols:keyboard-arrow-down-rounded" class="text-[1.2rem] transition-transform duration-200 dropdown-arrow absolute right-2.5 top-1/2 -translate-y-1/2" />
 		</button>
 		<div class="dropdown-menu" data-dropdown-menu>
 			<DropdownPanel class="dropdown-content">
-				{processedLink.children?.map((child, index) => (
+				{processedLink.children?.map((child, index) => {
+					const childIconInfo = getIconInfo(child.icon, child.iconurl);
+					return (
 					<DropdownItem
 						href={child.external ? child.url : url(child.url)}
 						target={child.external ? "_blank" : undefined}
 						isLast={index === (processedLink.children?.length || 0) - 1}
 						class="dropdown-item h-10"
 					>
-						{child.icon && <Icon is:inline name={child.icon} class="text-[1.25rem] mr-3 navbar-icon" />}
+						{childIconInfo && (
+							childIconInfo.isUrl
+								? <img src={childIconInfo.src} alt="" class="text-[1.25rem] mr-3 navbar-icon w-[1.25rem] h-[1.25rem]" />
+								: <Icon is:inline name={childIconInfo.src} class="text-[1.25rem] mr-3 navbar-icon" />
+						)}
 						<span>{child.name}</span>
 						{child.external && (
 							<Icon is:inline name="fa7-solid:arrow-up-right-from-square" class="text-[0.75rem] text-black/25 dark:text-white/25 ml-auto" />
 						)}
 					</DropdownItem>
-				))}
+					);
+				})}
 			</DropdownPanel>
 		</div>
 	) : (
@@ -62,7 +84,11 @@ const hasChildren = processedLink.children && processedLink.children.length > 0;
 			class="btn-plain scale-animation rounded-lg h-10 font-bold px-4 active:scale-95"
 		>
 			<div class="flex items-center gap-1.5">
-				{processedLink.icon && <Icon is:inline name={processedLink.icon} class="text-[1.1rem] mr-1.5 navbar-icon" />}
+				{linkIconInfo && (
+					linkIconInfo.isUrl
+						? <img src={linkIconInfo.src} alt="" class="text-[1.1rem] mr-1.5 navbar-icon w-[1.1rem] h-[1.1rem]" />
+						: <Icon is:inline name={linkIconInfo.src} class="text-[1.1rem] mr-1.5 navbar-icon" />
+				)}
 				{processedLink.name}
 				{processedLink.external && <Icon is:inline name="fa7-solid:arrow-up-right-from-square" class="text-[0.875rem] transition -translate-y-px ml-1 text-black/20 dark:text-white/20" />}
 			</div>

--- a/src/components/layout/NavMenuPanel.astro
+++ b/src/components/layout/NavMenuPanel.astro
@@ -8,9 +8,21 @@ interface Props {
 }
 
 const processedLinks = Astro.props.links;
+
+// 判断图标是否为 URL（支持 iconUrl 字段或以 http/https/相对路径开头的 icon）
+function getIconInfo(icon?: string, iconUrl?: string): { isUrl: boolean; src: string } | null {
+	if (iconUrl) return { isUrl: true, src: iconUrl };
+	if (!icon) return null;
+	if (icon.startsWith("http://") || icon.startsWith("https://") || icon.startsWith("//") || icon.startsWith("/")) {
+		return { isUrl: true, src: icon };
+	}
+	return { isUrl: false, src: icon };
+}
 ---
 <div id="nav-menu-panel" class:list={["float-panel float-panel-closed transition-all fixed right-4 px-2 py-2 max-h-[80vh] overflow-y-auto"]}>
-    {processedLinks.map((link) => (
+    {processedLinks.map((link) => {
+        const linkIconInfo = getIconInfo(link.icon, link.iconurl);
+        return (
         <div class="mobile-menu-item">
             {link.children && link.children.length > 0 ? (
                 <!-- 有子菜单的项目 -->
@@ -22,7 +34,11 @@ const processedLinks = Astro.props.links;
                         aria-expanded="false"
                     >
                         <div class="flex items-center transition text-black/75 dark:text-white/75 font-bold group-hover:text-(--primary) group-active:text-(--primary)">
-							{link.icon && <Icon is:inline name={link.icon} class="text-[1.1rem] mr-2" />}
+							{linkIconInfo && (
+								linkIconInfo.isUrl
+									? <img src={linkIconInfo.src} alt="" class="text-[1.1rem] mr-2 w-[1.1rem] h-[1.1rem]" />
+									: <Icon is:inline name={linkIconInfo.src} class="text-[1.1rem] mr-2" />
+							)}
                             {link.name}
                         </div>
                         <Icon is:inline name="material-symbols:keyboard-arrow-down-rounded"
@@ -30,21 +46,28 @@ const processedLinks = Astro.props.links;
                         />
                     </button>
                     <div class="mobile-submenu" data-mobile-submenu>
-                        {link.children.map((child) => (
+                        {link.children.map((child) => {
+                            const childIconInfo = getIconInfo(child.icon, child.iconurl);
+                            return (
                             <a href={child.external ? child.url : url(child.url)}
                                class="group flex justify-between items-center py-2 pl-6 pr-1 rounded-lg gap-8
                                    hover:bg-(--btn-plain-bg-hover) active:bg-(--btn-plain-bg-active) transition"
                                target={child.external ? "_blank" : null}
                             >
                                 <div class="flex items-center transition text-black/60 dark:text-white/60 font-medium group-hover:text-(--primary) group-active:text-(--primary)">
-									{child.icon && <Icon is:inline name={child.icon} class="text-[1.1rem] mr-2" />}
+									{childIconInfo && (
+										childIconInfo.isUrl
+											? <img src={childIconInfo.src} alt="" class="text-[1.1rem] mr-2 w-[1.1rem] h-[1.1rem]" />
+											: <Icon is:inline name={childIconInfo.src} class="text-[1.1rem] mr-2" />
+									)}
                                     {child.name}
                                 </div>
                                 {child.external && <Icon is:inline name="fa7-solid:arrow-up-right-from-square"
                                       class="transition text-[0.75rem] text-black/25 dark:text-white/25 -translate-x-1"
                                 />}
                             </a>
-                        ))}
+                            );
+                        })}
                     </div>
                 </div>
             ) : (
@@ -55,7 +78,11 @@ const processedLinks = Astro.props.links;
                    target={link.external ? "_blank" : null}
                 >
                     <div class="flex items-center transition text-black/75 dark:text-white/75 font-bold group-hover:text-(--primary) group-active:text-(--primary)">
-						{link.icon && <Icon is:inline name={link.icon} class="text-[1.1rem] mr-2" />}
+						{linkIconInfo && (
+							linkIconInfo.isUrl
+								? <img src={linkIconInfo.src} alt="" class="text-[1.1rem] mr-2 w-[1.1rem] h-[1.1rem]" />
+								: <Icon is:inline name={linkIconInfo.src} class="text-[1.1rem] mr-2" />
+						)}
                         {link.name}
                     </div>
 					{!link.external && <Icon is:inline name="material-symbols:chevron-right-rounded"
@@ -67,7 +94,8 @@ const processedLinks = Astro.props.links;
                 </a>
             )}
         </div>
-    ))}
+        );
+    })}
 </div>
 
 <style>

--- a/src/types/navBarConfig.ts
+++ b/src/types/navBarConfig.ts
@@ -2,7 +2,8 @@ export type NavBarLink = {
 	name: string;
 	url: string;
 	external?: boolean;
-	icon?: string; // 菜单项图标
+	icon?: string; // 菜单项图标（iconify 图标名 或 URL）
+	iconurl?: string; // 菜单项图标 URL（支持 http/https/相对路径）
 	children?: NavBarLink[]; // 支持子菜单
 	pageKey?: string;
 };


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

导航栏图标（`NavBarLink`）原先仅支持 iconify 图标名称，现在支持填写 URL 图标（远程图片或本地相对路径图片）。

具体修改：

1. **`src/types/navBarConfig.ts`** — `NavBarLink` 类型新增 `iconurl` 可选字段，`icon` 字段本身也支持直接填写 URL
2. **`src/components/layout/DropdownMenu.astro`** — 桌面端二级菜单：新增 `getIconInfo()` 辅助函数，自动判断图标是 iconify 图标名还是 URL，URL 时渲染 `<img>` 标签
3. **`src/components/layout/NavMenuPanel.astro`** — 移动端菜单：同样支持 URL 图标渲染

使用方式：

```ts
// 方式1：icon 字段直接填 URL
{ name: "GitHub", icon: "https://example.com/icon.svg" }

// 方式2：使用 iconurl 字段
{ name: "GitHub", iconurl: "/assets/icons/github.svg" }

## Summary by Sourcery

在桌面端和移动端菜单中，为导航链接新增对基于 URL 的图标的支持。

新功能：
- 允许 NavBarLink 项目通过 iconify 名称或直接 URL 指定图标，并新增专用的 `iconurl` 字段。
- 在桌面端下拉菜单和移动端导航面板中，将基于 URL 的导航图标渲染为图像。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for using URL-based icons in navigation links across both desktop and mobile menus.

New Features:
- Allow NavBarLink items to specify icons via either an iconify name or a direct URL, including a dedicated iconurl field.
- Render URL-based navigation icons as images in the desktop dropdown menu and mobile navigation panel.

</details>