### PR TITLE
使用Astro's Font API替换原CDN引用

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import { pluginCollapsibleSections } from "@expressive-code/plugin-collapsible-s
 import { pluginLineNumbers } from "@expressive-code/plugin-line-numbers";
 import swup from "@swup/astro";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 import expressiveCode from "astro-expressive-code";
 import icon from "astro-icon";
 import katex from "katex";
@@ -64,6 +64,39 @@ export default defineConfig({
 		// 全局响应式布局
 		layout: "constrained",
 	},
+
+	// Astro Font API - 自托管字体，自动优化加载性能和隐私
+	fonts: [
+		{
+			provider: fontProviders.google(),
+			name: "Inter",
+			cssVariable: "--font-inter",
+			weights: [300, 400, 500, 600, 700],
+			styles: ["normal"],
+		},
+		{
+			provider: fontProviders.google(),
+			name: "Zen Maru Gothic",
+			cssVariable: "--font-zen-maru-gothic",
+			weights: [300, 400, 500, 700, 900],
+			styles: ["normal"],
+		},
+		{
+			provider: fontProviders.local(),
+			name: "JetBrains Mono",
+			cssVariable: "--font-code",
+			fallbacks: ["ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"],
+			options: {
+				variants: [
+					{
+						src: ["./node_modules/@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2"],
+						weight: "100 800",
+						style: "normal",
+					},
+				],
+			},
+		},
+	],
 
 	integrations: [
 		swup({
@@ -147,7 +180,7 @@ export default defineConfig({
 				borderRadius: "0.75rem",
 				codeFontSize: "0.875rem",
 				codeFontFamily:
-					"'JetBrains Mono Variable', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+					"var(--font-code), 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
 				codeLineHeight: "1.5rem",
 				frames: {},
 				textMarkers: {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,7 @@ import { pluginLineNumbers } from "@expressive-code/plugin-line-numbers";
 import swup from "@swup/astro";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig, fontProviders } from "astro/config";
+import { fontApiCssVariables } from "./src/constants/font-api.ts";
 import expressiveCode from "astro-expressive-code";
 import icon from "astro-icon";
 import katex from "katex";
@@ -70,21 +71,21 @@ export default defineConfig({
 		{
 			provider: fontProviders.google(),
 			name: "Inter",
-			cssVariable: "--font-inter",
+			cssVariable: fontApiCssVariables.inter,
 			weights: [300, 400, 500, 600, 700],
 			styles: ["normal"],
 		},
 		{
 			provider: fontProviders.google(),
 			name: "Zen Maru Gothic",
-			cssVariable: "--font-zen-maru-gothic",
+			cssVariable: fontApiCssVariables["zen-maru-gothic"],
 			weights: [300, 400, 500, 700, 900],
 			styles: ["normal"],
 		},
 		{
 			provider: fontProviders.local(),
 			name: "JetBrains Mono",
-			cssVariable: "--font-code",
+			cssVariable: fontApiCssVariables["jetbrains-mono"],
 			fallbacks: ["ui-monospace", "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"],
 			options: {
 				variants: [

--- a/src/components/common/Markdown.astro
+++ b/src/components/common/Markdown.astro
@@ -1,7 +1,5 @@
 ---
-// 只加载基础的等宽字体，减少加载时间
-import "@fontsource-variable/jetbrains-mono";
-
+// JetBrains Mono 字体已通过 Astro Font API 加载 (astro.config.mjs fonts 配置)
 interface Props {
 	class: string;
 }

--- a/src/components/features/FontManager.astro
+++ b/src/components/features/FontManager.astro
@@ -119,14 +119,14 @@ const navbarTitleFontFamily =
 {fontConfig.enable && fontFamilyStyle && (
 	<style set:html={`
 :root {
-	--font-family-custom: ${selectedFonts.filter((f) => f.src).map((f) => `"${f.family}"`).join(", ")};
+	--font-family-custom: ${selectedFonts.map((f) => `"${f.family}"`).join(", ")};
 	--font-family-fallback: ${fallbacks.join(", ")};
 	${bannerTitleFontFamily ? `--font-banner-title: ${bannerTitleFontFamily};` : ""}
 	${bannerSubtitleFontFamily ? `--font-banner-subtitle: ${bannerSubtitleFontFamily};` : ""}
 	${navbarTitleFontFamily ? `--font-navbar-title: ${navbarTitleFontFamily};` : ""}
 }
 body { ${fontFamilyStyle} }
-${selectedFonts.filter((f) => f.src).map((f) => `.font-${f.id}, .font-${f.id} * { font-family: "${f.family}", var(--font-family-fallback) !important; }`).join("\n")}
+${selectedFonts.map((f) => `.font-${f.id}, .font-${f.id} * { font-family: "${f.family}", var(--font-family-fallback) !important; }`).join("\n")}
 `} />
 )}
 

--- a/src/components/features/FontManager.astro
+++ b/src/components/features/FontManager.astro
@@ -1,5 +1,5 @@
 ---
-import { type CssVariable, Font } from "astro:assets";
+import { Font } from "astro:assets";
 import { fontConfig } from "@/config";
 import { fontApiCssVariables } from "@/constants/font-api";
 
@@ -65,6 +65,14 @@ const fontFamilyStyle =
 		? `font-family: ${[...selectedFonts.map((f) => `"${f.family}"`), ...fallbacks].join(", ")};`
 		: "";
 
+// 辅助函数：解析本地字体的 src/格式/type（@font-face 和 preload 共用）
+const resolveLocalFont = (font: (typeof localFonts)[number]) => {
+	const isSubset = font.subset && !import.meta.env.DEV;
+	const src = isSubset ? `__SUBSET_FONT_${font.id}__` : font.src;
+	const format = isSubset ? "woff2" : font.format || "woff2";
+	return { src, format };
+};
+
 const bannerTitleFontFamily =
 	fontConfig.enable && fontConfig.bannerTitleFont
 		? resolveAreaFontValue(fontConfig.bannerTitleFont)
@@ -84,7 +92,7 @@ const navbarTitleFontFamily =
 	fontConfig.enable &&
 		Object.entries(fontApiCssVariables).map(([fontId, cssVar]) => {
 			const shouldPreload = fontConfig.preload && fontConfig.bannerTitleFont === fontId;
-			return <Font cssVariable={cssVar as CssVariable} preload={shouldPreload || undefined} />;
+			return <Font cssVariable={cssVar} preload={shouldPreload || undefined} />;
 		})
 }
 
@@ -93,21 +101,17 @@ const navbarTitleFontFamily =
 
 <!-- 非 Font API 管理的本地字体文件 -->
 {localFonts.map((font) => {
-	const isSubset = font.subset && !import.meta.env.DEV;
-	const fontSrc = isSubset ? `__SUBSET_FONT_${font.id}__` : font.src;
-	const fontFormat = isSubset ? 'format("woff2")' : font.format ? `format("${font.format}")` : "";
+	const { src, format } = resolveLocalFont(font);
 	return (
-		<style set:html={`@font-face { font-family: "${font.family}"; src: url("${fontSrc}") ${fontFormat};${font.weight ? ` font-weight: ${font.weight};` : ""}${font.style ? ` font-style: ${font.style};` : ""}${font.display ? ` font-display: ${font.display};` : ""}${font.unicodeRange ? ` unicode-range: ${font.unicodeRange};` : ""} }`} />
+		<style set:html={`@font-face { font-family: "${font.family}"; src: url("${src}") format("${format}");${font.weight ? ` font-weight: ${font.weight};` : ""}${font.style ? ` font-style: ${font.style};` : ""}${font.display ? ` font-display: ${font.display};` : ""}${font.unicodeRange ? ` unicode-range: ${font.unicodeRange};` : ""} }`} />
 	);
 })}
 
 <!-- 本地字体预加载（localFonts 已排除外部 URL，无需再过滤） -->
 {
 	fontConfig.enable && fontConfig.preload && localFonts.map((font) => {
-		const isSubset = font.subset && !import.meta.env.DEV;
-		const href = isSubset ? `__SUBSET_FONT_${font.id}__` : font.src;
-		const type = isSubset ? "font/woff2" : `font/${font.format || "woff2"}`;
-		return <link rel="preload" href={href} as="font" type={type} crossorigin />;
+		const { src, format } = resolveLocalFont(font);
+		return <link rel="preload" href={src} as="font" type={`font/${format}`} crossorigin />;
 	})
 }
 

--- a/src/components/features/FontManager.astro
+++ b/src/components/features/FontManager.astro
@@ -1,22 +1,7 @@
 ---
-import { Font, type CssVariable } from "astro:assets";
+import { type CssVariable, Font } from "astro:assets";
 import { fontConfig } from "@/config";
-
-// 统一解析 selected 为数组
-const selectedIds: string[] =
-	fontConfig.enable && fontConfig.selected
-		? Array.isArray(fontConfig.selected)
-			? fontConfig.selected
-			: [fontConfig.selected]
-		: [];
-
-// 字体 ID → Font API CSS 变量的映射
-// Astro Font API 会根据 astro.config.mjs 中的 fonts 配置自动下载并自托管这些字体
-const fontApiCssVariables: Record<string, CssVariable> = {
-	inter: "--font-inter",
-	"zen-maru-gothic": "--font-zen-maru-gothic",
-	"jetbrains-mono": "--font-code",
-};
+import { fontApiCssVariables } from "@/constants/font-api";
 
 const isFontApiManaged = (fontId: string) => fontId in fontApiCssVariables;
 
@@ -28,62 +13,57 @@ const resolveFontFamily = (fontId: string): string => {
 	return [`"${font.family}"`, ...fallbacks].join(", ");
 };
 
-// 非 Font API 管理的外部字体（需通过 <link> 标签加载）
+// 各区域独立字体 CSS 变量值（Font API 字体引用 CSS 变量，其他用 font-family 值）
+const resolveAreaFontValue = (fontId: string): string => {
+	if (!fontId) return "";
+	if (isFontApiManaged(fontId)) return `var(${fontApiCssVariables[fontId]})`;
+	return resolveFontFamily(fontId);
+};
+
+// 收集所有需要处理的字体 ID（selected + 各区域独立字体，去重）
+const selectedIds: string[] =
+	fontConfig.enable && fontConfig.selected
+		? Array.isArray(fontConfig.selected)
+			? fontConfig.selected
+			: [fontConfig.selected]
+		: [];
 const allFontIds = new Set(selectedIds);
 if (fontConfig.bannerTitleFont) allFontIds.add(fontConfig.bannerTitleFont);
 if (fontConfig.bannerSubtitleFont)
 	allFontIds.add(fontConfig.bannerSubtitleFont);
 if (fontConfig.navbarTitleFont) allFontIds.add(fontConfig.navbarTitleFont);
 
-const externalFontsToLoad = Array.from(allFontIds)
+// 一次遍历，按类型分区：external（CDN）、local（文件）、api（Font API）
+const allFonts = Array.from(allFontIds)
 	.map((id) => fontConfig.fonts[id])
-	.filter(
-		(font) =>
-			font?.src &&
-			!isFontApiManaged(font.id) &&
-			(font.src.startsWith("http://") ||
-				font.src.startsWith("https://") ||
-				font.src.startsWith("//")),
-	);
+	.filter(Boolean);
 
-// 非 Font API 管理的本地字体
-const localFontsToLoad = Array.from(allFontIds)
-	.map((id) => fontConfig.fonts[id])
-	.filter(
-		(font) =>
-			font?.src &&
-			!isFontApiManaged(font.id) &&
-			!font.src.startsWith("http://") &&
-			!font.src.startsWith("https://") &&
-			!font.src.startsWith("//"),
-	);
+const externalFonts: typeof allFonts = [];
+const localFonts: typeof allFonts = [];
+for (const font of allFonts) {
+	if (isFontApiManaged(font.id)) continue;
+	if (!font.src) continue;
+	if (
+		font.src.startsWith("http://") ||
+		font.src.startsWith("https://") ||
+		font.src.startsWith("//")
+	) {
+		externalFonts.push(font);
+	} else {
+		localFonts.push(font);
+	}
+}
 
-// 全局 selected 中有 src 的字体（排除系统字体）
-const selectedFontsWithSrc = selectedIds
+// selected 中的所有有效字体（含 Font API 字体，用于 body font-family 和 .font-* 类）
+const selectedFonts = selectedIds
 	.map((id) => fontConfig.fonts[id])
-	.filter((font) => font?.src);
-
-// 生成 font-family 回退样式
-const selectedFontFamilies = selectedIds
-	.map((id) => fontConfig.fonts[id])
-	.filter((font) => font)
-	.map((font) => `"${font?.family ?? ""}"`);
+	.filter(Boolean);
 
 const fallbacks = fontConfig.fallback || [];
 const fontFamilyStyle =
-	selectedFontFamilies.length > 0
-		? `font-family: ${[...selectedFontFamilies, ...fallbacks].join(", ")};`
+	selectedFonts.length > 0
+		? `font-family: ${[...selectedFonts.map((f) => `"${f.family}"`), ...fallbacks].join(", ")};`
 		: "";
-
-// 生成各区域独立字体 CSS 变量值
-// 对于 Font API 管理的字体，引用 Font API 的 CSS 变量
-const resolveAreaFontValue = (fontId: string): string => {
-	if (!fontId) return "";
-	if (isFontApiManaged(fontId)) {
-		return `var(${fontApiCssVariables[fontId]})`;
-	}
-	return resolveFontFamily(fontId);
-};
 
 const bannerTitleFontFamily =
 	fontConfig.enable && fontConfig.bannerTitleFont
@@ -103,114 +83,53 @@ const navbarTitleFontFamily =
 {
 	fontConfig.enable &&
 		Object.entries(fontApiCssVariables).map(([fontId, cssVar]) => {
-			// 横幅标题字体是首屏关键字体，启用预加载
-			const shouldPreload =
-				fontConfig.preload && fontConfig.bannerTitleFont === fontId;
-			return <Font cssVariable={cssVar} preload={shouldPreload || undefined} />;
+			const shouldPreload = fontConfig.preload && fontConfig.bannerTitleFont === fontId;
+			return <Font cssVariable={cssVar as CssVariable} preload={shouldPreload || undefined} />;
 		})
 }
 
-<!-- 非 Font API 管理的外部字体链接 (如第三方 CDN) -->
-{
-	externalFontsToLoad.map((font) => (
-		<link rel="stylesheet" href={font.src} />
-	))
-}
+<!-- 非 Font API 管理的外部字体链接 -->
+{externalFonts.map((font) => <link rel="stylesheet" href={font.src} />)}
 
 <!-- 非 Font API 管理的本地字体文件 -->
+{localFonts.map((font) => {
+	const isSubset = font.subset && !import.meta.env.DEV;
+	const fontSrc = isSubset ? `__SUBSET_FONT_${font.id}__` : font.src;
+	const fontFormat = isSubset ? 'format("woff2")' : font.format ? `format("${font.format}")` : "";
+	return (
+		<style set:html={`@font-face { font-family: "${font.family}"; src: url("${fontSrc}") ${fontFormat};${font.weight ? ` font-weight: ${font.weight};` : ""}${font.style ? ` font-style: ${font.style};` : ""}${font.display ? ` font-display: ${font.display};` : ""}${font.unicodeRange ? ` unicode-range: ${font.unicodeRange};` : ""} }`} />
+	);
+})}
+
+<!-- 本地字体预加载（localFonts 已排除外部 URL，无需再过滤） -->
 {
-	localFontsToLoad.map((font) => {
+	fontConfig.enable && fontConfig.preload && localFonts.map((font) => {
 		const isSubset = font.subset && !import.meta.env.DEV;
-		const fontSrc = isSubset ? `__SUBSET_FONT_${font.id}__` : font.src;
-		const fontFormat = isSubset
-			? 'format("woff2")'
-			: font.format
-				? `format("${font.format}")`
-				: "";
-		return (
-			<style
-				set:html={`
-			@font-face {
-				font-family: "${font.family}";
-				src: url("${fontSrc}") ${fontFormat};
-				${font.weight ? `font-weight: ${font.weight};` : ""}
-				${font.style ? `font-style: ${font.style};` : ""}
-				${font.display ? `font-display: ${font.display};` : ""}
-				${font.unicodeRange ? `unicode-range: ${font.unicodeRange};` : ""}
-			}
-		`}
-			/>
-		);
+		const href = isSubset ? `__SUBSET_FONT_${font.id}__` : font.src;
+		const type = isSubset ? "font/woff2" : `font/${font.format || "woff2"}`;
+		return <link rel="preload" href={href} as="font" type={type} crossorigin />;
 	})
 }
 
-<!-- 本地字体预加载 -->
-{
-	fontConfig.enable &&
-		fontConfig.preload &&
-		localFontsToLoad
-			.filter((font) => !font.src.startsWith("http"))
-			.map((font) => {
-				const isSubset = font.subset && !import.meta.env.DEV;
-				const href = isSubset ? `__SUBSET_FONT_${font.id}__` : font.src;
-				const type = isSubset
-					? "font/woff2"
-					: `font/${font.format || "woff2"}`;
-				return (
-					<link
-						rel="preload"
-						href={href}
-						as="font"
-						type={type}
-						crossorigin
-					/>
-				);
-			})
-}
-
 <!-- 全局字体样式 -->
-{
-	fontConfig.enable && fontFamilyStyle && (
-		<style
-			set:html={`
-		:root {
-			--font-family-custom: ${selectedFontsWithSrc.map((font) => `"${font.family}"`).join(", ")};
-			--font-family-fallback: ${(fontConfig.fallback || []).join(", ")};
-			${bannerTitleFontFamily ? `--font-banner-title: ${bannerTitleFontFamily};` : ""}
-			${bannerSubtitleFontFamily ? `--font-banner-subtitle: ${bannerSubtitleFontFamily};` : ""}
-			${navbarTitleFontFamily ? `--font-navbar-title: ${navbarTitleFontFamily};` : ""}
-		}
-
-		/* 应用自定义字体到body */
-		body {
-			${fontFamilyStyle}
-		}
-
-		/* 为每个选中的字体生成对应的CSS类 */
-		${selectedFontsWithSrc
-			.map((font) => {
-				return `
-			.font-${font.id},
-			.font-${font.id} * {
-				font-family: "${font.family}", var(--font-family-fallback) !important;
-			}
-		`;
-			})
-			.join("\n")}
-	`}
-		/>
-	)
+{fontConfig.enable && fontFamilyStyle && (
+	<style set:html={`
+:root {
+	--font-family-custom: ${selectedFonts.filter((f) => f.src).map((f) => `"${f.family}"`).join(", ")};
+	--font-family-fallback: ${fallbacks.join(", ")};
+	${bannerTitleFontFamily ? `--font-banner-title: ${bannerTitleFontFamily};` : ""}
+	${bannerSubtitleFontFamily ? `--font-banner-subtitle: ${bannerSubtitleFontFamily};` : ""}
+	${navbarTitleFontFamily ? `--font-navbar-title: ${navbarTitleFontFamily};` : ""}
 }
+body { ${fontFamilyStyle} }
+${selectedFonts.filter((f) => f.src).map((f) => `.font-${f.id}, .font-${f.id} * { font-family: "${f.family}", var(--font-family-fallback) !important; }`).join("\n")}
+`} />
+)}
 
 <script>
-	// 字体加载完成事件
 	if (document.fonts && typeof document.fonts.ready !== "undefined") {
 		document.fonts.ready
-			.then(() => {
-				document.dispatchEvent(new CustomEvent("fontsLoaded"));
-			})
-			.catch((error: Error) => {
-				console.warn("Font loading failed:", error);
-			});
+			.then(() => { document.dispatchEvent(new CustomEvent("fontsLoaded")); })
+			.catch((error: Error) => { console.warn("Font loading failed:", error); });
 	}
 </script>

--- a/src/components/features/FontManager.astro
+++ b/src/components/features/FontManager.astro
@@ -1,4 +1,5 @@
 ---
+import { Font, type CssVariable } from "astro:assets";
 import { fontConfig } from "@/config";
 
 // 统一解析 selected 为数组
@@ -9,7 +10,17 @@ const selectedIds: string[] =
 			: [fontConfig.selected]
 		: [];
 
-// 解析字体ID为完整的 font-family CSS 值
+// 字体 ID → Font API CSS 变量的映射
+// Astro Font API 会根据 astro.config.mjs 中的 fonts 配置自动下载并自托管这些字体
+const fontApiCssVariables: Record<string, CssVariable> = {
+	inter: "--font-inter",
+	"zen-maru-gothic": "--font-zen-maru-gothic",
+	"jetbrains-mono": "--font-code",
+};
+
+const isFontApiManaged = (fontId: string) => fontId in fontApiCssVariables;
+
+// 解析字体ID为完整的 font-family CSS 值（用于非 Font API 字体）
 const resolveFontFamily = (fontId: string): string => {
 	const font = fontConfig.fonts[fontId];
 	if (!font) return "";
@@ -17,19 +28,38 @@ const resolveFontFamily = (fontId: string): string => {
 	return [`"${font.family}"`, ...fallbacks].join(", ");
 };
 
-// 全局 selected 中有 src 的字体（排除系统字体）
-const selectedFonts = selectedIds
-	.map((id) => fontConfig.fonts[id])
-	.filter((font) => font?.src);
-
-// 需要加载的所有字体（selected + 各区域独立字体，去重）
+// 非 Font API 管理的外部字体（需通过 <link> 标签加载）
 const allFontIds = new Set(selectedIds);
 if (fontConfig.bannerTitleFont) allFontIds.add(fontConfig.bannerTitleFont);
 if (fontConfig.bannerSubtitleFont)
 	allFontIds.add(fontConfig.bannerSubtitleFont);
 if (fontConfig.navbarTitleFont) allFontIds.add(fontConfig.navbarTitleFont);
 
-const allFontsToLoad = Array.from(allFontIds)
+const externalFontsToLoad = Array.from(allFontIds)
+	.map((id) => fontConfig.fonts[id])
+	.filter(
+		(font) =>
+			font?.src &&
+			!isFontApiManaged(font.id) &&
+			(font.src.startsWith("http://") ||
+				font.src.startsWith("https://") ||
+				font.src.startsWith("//")),
+	);
+
+// 非 Font API 管理的本地字体
+const localFontsToLoad = Array.from(allFontIds)
+	.map((id) => fontConfig.fonts[id])
+	.filter(
+		(font) =>
+			font?.src &&
+			!isFontApiManaged(font.id) &&
+			!font.src.startsWith("http://") &&
+			!font.src.startsWith("https://") &&
+			!font.src.startsWith("//"),
+	);
+
+// 全局 selected 中有 src 的字体（排除系统字体）
+const selectedFontsWithSrc = selectedIds
 	.map((id) => fontConfig.fonts[id])
 	.filter((font) => font?.src);
 
@@ -46,124 +76,141 @@ const fontFamilyStyle =
 		: "";
 
 // 生成各区域独立字体 CSS 变量值
+// 对于 Font API 管理的字体，引用 Font API 的 CSS 变量
+const resolveAreaFontValue = (fontId: string): string => {
+	if (!fontId) return "";
+	if (isFontApiManaged(fontId)) {
+		return `var(${fontApiCssVariables[fontId]})`;
+	}
+	return resolveFontFamily(fontId);
+};
+
 const bannerTitleFontFamily =
 	fontConfig.enable && fontConfig.bannerTitleFont
-		? resolveFontFamily(fontConfig.bannerTitleFont)
+		? resolveAreaFontValue(fontConfig.bannerTitleFont)
 		: "";
 const bannerSubtitleFontFamily =
 	fontConfig.enable && fontConfig.bannerSubtitleFont
-		? resolveFontFamily(fontConfig.bannerSubtitleFont)
+		? resolveAreaFontValue(fontConfig.bannerSubtitleFont)
 		: "";
 const navbarTitleFontFamily =
 	fontConfig.enable && fontConfig.navbarTitleFont
-		? resolveFontFamily(fontConfig.navbarTitleFont)
+		? resolveAreaFontValue(fontConfig.navbarTitleFont)
 		: "";
 ---
 
-<!-- 字体样式表链接 -->{
-  allFontsToLoad.map((font) => {
-    // 判断是否为外部链接
-    const isExternalUrl =
-      font.src.startsWith("http://") ||
-      font.src.startsWith("https://") ||
-      font.src.startsWith("//");
-
-    if (isExternalUrl) {
-      // 外部字体链接 (如 Google Fonts, CDN等)
-      return <link rel="stylesheet" href={font.src} />;
-    } else {
-      // 本地字体文件
-      // 如果启用了子集化且为构建模式，输出占位符供构建后脚本替换
-      const isSubset = font.subset && !import.meta.env.DEV;
-      const fontSrc = isSubset
-        ? `__SUBSET_FONT_${font.id}__`
-        : font.src;
-      const fontFormat = isSubset
-        ? 'format("woff2")'
-        : (font.format ? `format("${font.format}")` : "");
-      return (
-        <style
-          set:html={`
-        @font-face {
-          font-family: "${font.family}";
-          src: url("${fontSrc}") ${fontFormat};
-          ${font.weight ? `font-weight: ${font.weight};` : ""}
-          ${font.style ? `font-style: ${font.style};` : ""}
-          ${font.display ? `font-display: ${font.display};` : ""}
-          ${font.unicodeRange ? `unicode-range: ${font.unicodeRange};` : ""}
-        }
-      `}
-        />
-      );
-    }
-  })
+<!-- Astro Font API: 自托管字体，自动优化预加载和回退 -->
+{
+	fontConfig.enable &&
+		Object.entries(fontApiCssVariables).map(([fontId, cssVar]) => {
+			// 横幅标题字体是首屏关键字体，启用预加载
+			const shouldPreload =
+				fontConfig.preload && fontConfig.bannerTitleFont === fontId;
+			return <Font cssVariable={cssVar} preload={shouldPreload || undefined} />;
+		})
 }
 
-<!-- 字体预加载链接 -->
+<!-- 非 Font API 管理的外部字体链接 (如第三方 CDN) -->
 {
-  fontConfig.enable &&
-    fontConfig.preload &&
-    allFontsToLoad
-      .filter((font) => !font.src.startsWith("http"))
-      .map((font) => {
-        const isSubset = font.subset && !import.meta.env.DEV;
-        const href = isSubset ? `__SUBSET_FONT_${font.id}__` : font.src;
-        const type = isSubset ? "font/woff2" : `font/${font.format || "woff2"}`;
-        return (
-          <link
-            rel="preload"
-            href={href}
-            as="font"
-            type={type}
-            crossorigin
-          />
-        );
-      })
+	externalFontsToLoad.map((font) => (
+		<link rel="stylesheet" href={font.src} />
+	))
+}
+
+<!-- 非 Font API 管理的本地字体文件 -->
+{
+	localFontsToLoad.map((font) => {
+		const isSubset = font.subset && !import.meta.env.DEV;
+		const fontSrc = isSubset ? `__SUBSET_FONT_${font.id}__` : font.src;
+		const fontFormat = isSubset
+			? 'format("woff2")'
+			: font.format
+				? `format("${font.format}")`
+				: "";
+		return (
+			<style
+				set:html={`
+			@font-face {
+				font-family: "${font.family}";
+				src: url("${fontSrc}") ${fontFormat};
+				${font.weight ? `font-weight: ${font.weight};` : ""}
+				${font.style ? `font-style: ${font.style};` : ""}
+				${font.display ? `font-display: ${font.display};` : ""}
+				${font.unicodeRange ? `unicode-range: ${font.unicodeRange};` : ""}
+			}
+		`}
+			/>
+		);
+	})
+}
+
+<!-- 本地字体预加载 -->
+{
+	fontConfig.enable &&
+		fontConfig.preload &&
+		localFontsToLoad
+			.filter((font) => !font.src.startsWith("http"))
+			.map((font) => {
+				const isSubset = font.subset && !import.meta.env.DEV;
+				const href = isSubset ? `__SUBSET_FONT_${font.id}__` : font.src;
+				const type = isSubset
+					? "font/woff2"
+					: `font/${font.format || "woff2"}`;
+				return (
+					<link
+						rel="preload"
+						href={href}
+						as="font"
+						type={type}
+						crossorigin
+					/>
+				);
+			})
 }
 
 <!-- 全局字体样式 -->
 {
-  fontConfig.enable && fontFamilyStyle && (
-    <style
-      set:html={`
-    :root {
-      --font-family-custom: ${selectedFonts.map((font) => `"${font.family}"`).join(", ")};
-      --font-family-fallback: ${(fontConfig.fallback || []).join(", ")};
-      ${bannerTitleFontFamily ? `--font-banner-title: ${bannerTitleFontFamily};` : ""}
-      ${bannerSubtitleFontFamily ? `--font-banner-subtitle: ${bannerSubtitleFontFamily};` : ""}
-      ${navbarTitleFontFamily ? `--font-navbar-title: ${navbarTitleFontFamily};` : ""}
-    }
-    
-    /* 应用自定义字体到body */
-    body {
-      ${fontFamilyStyle}
-    }
-    
-    /* 为每个选中的字体生成对应的CSS类 */
-    ${selectedFonts
-      .map((font) => {
-        return `
-        .font-${font.id},
-        .font-${font.id} * {
-          font-family: "${font.family}", var(--font-family-fallback) !important;
-        }
-      `;
-      })
-      .join("\n")}
-  `}
-    />
-  )
+	fontConfig.enable && fontFamilyStyle && (
+		<style
+			set:html={`
+		:root {
+			--font-family-custom: ${selectedFontsWithSrc.map((font) => `"${font.family}"`).join(", ")};
+			--font-family-fallback: ${(fontConfig.fallback || []).join(", ")};
+			${bannerTitleFontFamily ? `--font-banner-title: ${bannerTitleFontFamily};` : ""}
+			${bannerSubtitleFontFamily ? `--font-banner-subtitle: ${bannerSubtitleFontFamily};` : ""}
+			${navbarTitleFontFamily ? `--font-navbar-title: ${navbarTitleFontFamily};` : ""}
+		}
+
+		/* 应用自定义字体到body */
+		body {
+			${fontFamilyStyle}
+		}
+
+		/* 为每个选中的字体生成对应的CSS类 */
+		${selectedFontsWithSrc
+			.map((font) => {
+				return `
+			.font-${font.id},
+			.font-${font.id} * {
+				font-family: "${font.family}", var(--font-family-fallback) !important;
+			}
+		`;
+			})
+			.join("\n")}
+	`}
+		/>
+	)
 }
 
 <script>
-  // 字体加载完成事件
-  if (document.fonts && typeof document.fonts.ready !== "undefined") {
-    document.fonts.ready
-      .then(() => {
-        document.dispatchEvent(new CustomEvent("fontsLoaded"));
-      })
-      .catch((error: Error) => {
-        console.warn("Font loading failed:", error);
-      });
-  }
+	// 字体加载完成事件
+	if (document.fonts && typeof document.fonts.ready !== "undefined") {
+		document.fonts.ready
+			.then(() => {
+				document.dispatchEvent(new CustomEvent("fontsLoaded"));
+			})
+			.catch((error: Error) => {
+				console.warn("Font loading failed:", error);
+			});
+	}
 </script>

--- a/src/config/fontConfig.ts
+++ b/src/config/fontConfig.ts
@@ -32,20 +32,20 @@ export const fontConfig: FontConfig = {
 				"system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif",
 		},
 
-		// Google Fonts - Zen Maru Gothic
+		// Google Fonts - Zen Maru Gothic (由 Astro Font API 加载，见 astro.config.mjs fonts 配置)
 		"zen-maru-gothic": {
 			id: "zen-maru-gothic",
 			name: "Zen Maru Gothic",
-			src: "https://fonts.googleapis.com/css2?family=Zen+Maru+Gothic:wght@300;400;500;700;900&display=swap",
+			src: "", // Font API 管理，src 留空
 			family: "Zen Maru Gothic",
 			display: "swap" as const,
 		},
 
-		// Google Fonts - Inter
+		// Google Fonts - Inter (由 Astro Font API 加载，见 astro.config.mjs fonts 配置)
 		inter: {
 			id: "inter",
 			name: "Inter",
-			src: "https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap",
+			src: "", // Font API 管理，src 留空
 			family: "Inter",
 			display: "swap" as const,
 		},

--- a/src/constants/font-api.ts
+++ b/src/constants/font-api.ts
@@ -1,10 +1,12 @@
+import type { CssVariable } from "astro:assets";
+
 /**
  * Font ID → Astro Font API CSS variable name mapping.
  *
- * MUST stay in sync with the `fonts` array in astro.config.mjs.
- * Each entry here corresponds to a font configured with fontProviders in Astro config.
+ * Each entry here corresponds to a font configured with fontProviders in astro.config.mjs.
+ * The `fonts` array in astro.config.mjs MUST reference these values via `fontApiCssVariables.*`.
  */
-export const fontApiCssVariables: Record<string, string> = {
+export const fontApiCssVariables: Record<string, CssVariable> = {
 	inter: "--font-inter",
 	"zen-maru-gothic": "--font-zen-maru-gothic",
 	"jetbrains-mono": "--font-code",

--- a/src/constants/font-api.ts
+++ b/src/constants/font-api.ts
@@ -3,11 +3,14 @@ import type { CssVariable } from "astro:assets";
 /**
  * Font ID → Astro Font API CSS variable name mapping.
  *
- * Each entry here corresponds to a font configured with fontProviders in astro.config.mjs.
- * The `fonts` array in astro.config.mjs MUST reference these values via `fontApiCssVariables.*`.
+ * Each entry here MUST have a corresponding `fonts` entry in astro.config.mjs
+ * using `fontApiCssVariables.<key>` as the `cssVariable` value.
+ * Both files reference this map, so renaming a key here will cause a build error there.
+ *
+ * Adding a new entry requires updating BOTH this file AND astro.config.mjs.
  */
-export const fontApiCssVariables: Record<string, CssVariable> = {
-	inter: "--font-inter",
-	"zen-maru-gothic": "--font-zen-maru-gothic",
-	"jetbrains-mono": "--font-code",
-};
+export const fontApiCssVariables = {
+	inter: "--font-inter" as CssVariable,
+	"zen-maru-gothic": "--font-zen-maru-gothic" as CssVariable,
+	"jetbrains-mono": "--font-code" as CssVariable,
+} as const;

--- a/src/constants/font-api.ts
+++ b/src/constants/font-api.ts
@@ -1,0 +1,11 @@
+/**
+ * Font ID → Astro Font API CSS variable name mapping.
+ *
+ * MUST stay in sync with the `fonts` array in astro.config.mjs.
+ * Each entry here corresponds to a font configured with fontProviders in Astro config.
+ */
+export const fontApiCssVariables: Record<string, string> = {
+	inter: "--font-inter",
+	"zen-maru-gothic": "--font-zen-maru-gothic",
+	"jetbrains-mono": "--font-code",
+};

--- a/src/styles/expressive-code.css
+++ b/src/styles/expressive-code.css
@@ -5,7 +5,7 @@
 
   .title {
     font-family:
-      "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco,
+      var(--font-code), "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
       Consolas, "Liberation Mono", "Courier New", monospace;
   }
 

--- a/src/styles/markdown.css
+++ b/src/styles/markdown.css
@@ -53,7 +53,8 @@
     @apply bg-(--inline-code-bg) text-(--inline-code-color) px-1 py-0.5 rounded-md overflow-hidden;
 
     font-family:
-      "JetBrains Mono Variable",
+      var(--font-code),
+      "JetBrains Mono",
       ui-monospace,
       SFMono-Regular,
       Menlo,


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->


## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->

## Summary by Sourcery

集成 Astro 的 Font API 以管理站点的主字体，同时重构全局字体管理逻辑，将由 API 管理的字体与外部和本地字体区分开来。

新功能：
- 通过 Astro 的 Font API 配置 Inter、Zen Maru Gothic 和 JetBrains Mono，并提供相应的 CSS 变量以在整个应用中使用。

增强与改进：
- 重构全局 FontManager，将由 Astro Font API 管理的字体与外部和本地字体分离，同时保留现有的字体选择与回退行为。
- 将 Markdown、Expressive Code 和布局配置中直接导入 JetBrains Mono 以及硬编码的 `font-family` 值，替换为由 Astro 管理的代码字体支持的共享 CSS 变量。
- 精简本地 `@font-face` 生成和预加载逻辑，复用通用的辅助函数，并避免在自定义加载器中处理由 API 管理的字体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Astro's Font API for primary site fonts while refactoring global font management to distinguish API-managed fonts from external and local fonts.

New Features:
- Configure Inter, Zen Maru Gothic, and JetBrains Mono via Astro's Font API with corresponding CSS variables for use across the app.

Enhancements:
- Refactor the global FontManager to separate Astro Font API–managed fonts from external and local fonts while preserving existing selection and fallback behavior.
- Replace direct JetBrains Mono imports and hardcoded font-family values in Markdown, Expressive Code, and layout config with shared CSS variables backed by the Astro-managed code font.
- Streamline local font-face generation and preloading logic to reuse shared helpers and avoid handling API-managed fonts in custom loaders.

</details>

新特性：
- 通过 Astro 的字体 API 配置 Inter、Zen Maru Gothic 和 JetBrains Mono，实现自托管加载并提供 CSS 变量。
- 暴露字体 ID 到 CSS 变量的映射，在整个应用中用来引用由 Astro 管理的字体。

改进：
- 重构全局 FontManager，以区分 Astro 字体 API 管理的字体与外部/本地字体，同时保持现有的字体选择和回退行为不变。
- 更新 Markdown 和代码样式，使用共享的代码字体 CSS 变量，并依赖由 Astro 管理的 JetBrains Mono，而不是直接导入它。
- 调整排版配置，使 Expressive Code 及相关组件使用新的代码字体 CSS 变量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

集成 Astro 的 Font API 以管理站点的主字体，同时重构全局字体管理逻辑，将由 API 管理的字体与外部和本地字体区分开来。

新功能：
- 通过 Astro 的 Font API 配置 Inter、Zen Maru Gothic 和 JetBrains Mono，并提供相应的 CSS 变量以在整个应用中使用。

增强与改进：
- 重构全局 FontManager，将由 Astro Font API 管理的字体与外部和本地字体分离，同时保留现有的字体选择与回退行为。
- 将 Markdown、Expressive Code 和布局配置中直接导入 JetBrains Mono 以及硬编码的 `font-family` 值，替换为由 Astro 管理的代码字体支持的共享 CSS 变量。
- 精简本地 `@font-face` 生成和预加载逻辑，复用通用的辅助函数，并避免在自定义加载器中处理由 API 管理的字体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Astro's Font API for primary site fonts while refactoring global font management to distinguish API-managed fonts from external and local fonts.

New Features:
- Configure Inter, Zen Maru Gothic, and JetBrains Mono via Astro's Font API with corresponding CSS variables for use across the app.

Enhancements:
- Refactor the global FontManager to separate Astro Font API–managed fonts from external and local fonts while preserving existing selection and fallback behavior.
- Replace direct JetBrains Mono imports and hardcoded font-family values in Markdown, Expressive Code, and layout config with shared CSS variables backed by the Astro-managed code font.
- Streamline local font-face generation and preloading logic to reuse shared helpers and avoid handling API-managed fonts in custom loaders.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

集成 Astro 的 Font API 以管理站点的主字体，同时重构全局字体管理逻辑，将由 API 管理的字体与外部和本地字体区分开来。

新功能：
- 通过 Astro 的 Font API 配置 Inter、Zen Maru Gothic 和 JetBrains Mono，并提供相应的 CSS 变量以在整个应用中使用。

增强与改进：
- 重构全局 FontManager，将由 Astro Font API 管理的字体与外部和本地字体分离，同时保留现有的字体选择与回退行为。
- 将 Markdown、Expressive Code 和布局配置中直接导入 JetBrains Mono 以及硬编码的 `font-family` 值，替换为由 Astro 管理的代码字体支持的共享 CSS 变量。
- 精简本地 `@font-face` 生成和预加载逻辑，复用通用的辅助函数，并避免在自定义加载器中处理由 API 管理的字体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Astro's Font API for primary site fonts while refactoring global font management to distinguish API-managed fonts from external and local fonts.

New Features:
- Configure Inter, Zen Maru Gothic, and JetBrains Mono via Astro's Font API with corresponding CSS variables for use across the app.

Enhancements:
- Refactor the global FontManager to separate Astro Font API–managed fonts from external and local fonts while preserving existing selection and fallback behavior.
- Replace direct JetBrains Mono imports and hardcoded font-family values in Markdown, Expressive Code, and layout config with shared CSS variables backed by the Astro-managed code font.
- Streamline local font-face generation and preloading logic to reuse shared helpers and avoid handling API-managed fonts in custom loaders.

</details>

新特性：
- 通过 Astro 的字体 API 配置 Inter、Zen Maru Gothic 和 JetBrains Mono，实现自托管加载并提供 CSS 变量。
- 暴露字体 ID 到 CSS 变量的映射，在整个应用中用来引用由 Astro 管理的字体。

改进：
- 重构全局 FontManager，以区分 Astro 字体 API 管理的字体与外部/本地字体，同时保持现有的字体选择和回退行为不变。
- 更新 Markdown 和代码样式，使用共享的代码字体 CSS 变量，并依赖由 Astro 管理的 JetBrains Mono，而不是直接导入它。
- 调整排版配置，使 Expressive Code 及相关组件使用新的代码字体 CSS 变量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

集成 Astro 的 Font API 以管理站点的主字体，同时重构全局字体管理逻辑，将由 API 管理的字体与外部和本地字体区分开来。

新功能：
- 通过 Astro 的 Font API 配置 Inter、Zen Maru Gothic 和 JetBrains Mono，并提供相应的 CSS 变量以在整个应用中使用。

增强与改进：
- 重构全局 FontManager，将由 Astro Font API 管理的字体与外部和本地字体分离，同时保留现有的字体选择与回退行为。
- 将 Markdown、Expressive Code 和布局配置中直接导入 JetBrains Mono 以及硬编码的 `font-family` 值，替换为由 Astro 管理的代码字体支持的共享 CSS 变量。
- 精简本地 `@font-face` 生成和预加载逻辑，复用通用的辅助函数，并避免在自定义加载器中处理由 API 管理的字体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Astro's Font API for primary site fonts while refactoring global font management to distinguish API-managed fonts from external and local fonts.

New Features:
- Configure Inter, Zen Maru Gothic, and JetBrains Mono via Astro's Font API with corresponding CSS variables for use across the app.

Enhancements:
- Refactor the global FontManager to separate Astro Font API–managed fonts from external and local fonts while preserving existing selection and fallback behavior.
- Replace direct JetBrains Mono imports and hardcoded font-family values in Markdown, Expressive Code, and layout config with shared CSS variables backed by the Astro-managed code font.
- Streamline local font-face generation and preloading logic to reuse shared helpers and avoid handling API-managed fonts in custom loaders.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

集成 Astro 的 Font API 以管理站点的主字体，同时重构全局字体管理逻辑，将由 API 管理的字体与外部和本地字体区分开来。

新功能：
- 通过 Astro 的 Font API 配置 Inter、Zen Maru Gothic 和 JetBrains Mono，并提供相应的 CSS 变量以在整个应用中使用。

增强与改进：
- 重构全局 FontManager，将由 Astro Font API 管理的字体与外部和本地字体分离，同时保留现有的字体选择与回退行为。
- 将 Markdown、Expressive Code 和布局配置中直接导入 JetBrains Mono 以及硬编码的 `font-family` 值，替换为由 Astro 管理的代码字体支持的共享 CSS 变量。
- 精简本地 `@font-face` 生成和预加载逻辑，复用通用的辅助函数，并避免在自定义加载器中处理由 API 管理的字体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Astro's Font API for primary site fonts while refactoring global font management to distinguish API-managed fonts from external and local fonts.

New Features:
- Configure Inter, Zen Maru Gothic, and JetBrains Mono via Astro's Font API with corresponding CSS variables for use across the app.

Enhancements:
- Refactor the global FontManager to separate Astro Font API–managed fonts from external and local fonts while preserving existing selection and fallback behavior.
- Replace direct JetBrains Mono imports and hardcoded font-family values in Markdown, Expressive Code, and layout config with shared CSS variables backed by the Astro-managed code font.
- Streamline local font-face generation and preloading logic to reuse shared helpers and avoid handling API-managed fonts in custom loaders.

</details>

新特性：
- 通过 Astro 的字体 API 配置 Inter、Zen Maru Gothic 和 JetBrains Mono，实现自托管加载并提供 CSS 变量。
- 暴露字体 ID 到 CSS 变量的映射，在整个应用中用来引用由 Astro 管理的字体。

改进：
- 重构全局 FontManager，以区分 Astro 字体 API 管理的字体与外部/本地字体，同时保持现有的字体选择和回退行为不变。
- 更新 Markdown 和代码样式，使用共享的代码字体 CSS 变量，并依赖由 Astro 管理的 JetBrains Mono，而不是直接导入它。
- 调整排版配置，使 Expressive Code 及相关组件使用新的代码字体 CSS 变量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

集成 Astro 的 Font API 以管理站点的主字体，同时重构全局字体管理逻辑，将由 API 管理的字体与外部和本地字体区分开来。

新功能：
- 通过 Astro 的 Font API 配置 Inter、Zen Maru Gothic 和 JetBrains Mono，并提供相应的 CSS 变量以在整个应用中使用。

增强与改进：
- 重构全局 FontManager，将由 Astro Font API 管理的字体与外部和本地字体分离，同时保留现有的字体选择与回退行为。
- 将 Markdown、Expressive Code 和布局配置中直接导入 JetBrains Mono 以及硬编码的 `font-family` 值，替换为由 Astro 管理的代码字体支持的共享 CSS 变量。
- 精简本地 `@font-face` 生成和预加载逻辑，复用通用的辅助函数，并避免在自定义加载器中处理由 API 管理的字体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Astro's Font API for primary site fonts while refactoring global font management to distinguish API-managed fonts from external and local fonts.

New Features:
- Configure Inter, Zen Maru Gothic, and JetBrains Mono via Astro's Font API with corresponding CSS variables for use across the app.

Enhancements:
- Refactor the global FontManager to separate Astro Font API–managed fonts from external and local fonts while preserving existing selection and fallback behavior.
- Replace direct JetBrains Mono imports and hardcoded font-family values in Markdown, Expressive Code, and layout config with shared CSS variables backed by the Astro-managed code font.
- Streamline local font-face generation and preloading logic to reuse shared helpers and avoid handling API-managed fonts in custom loaders.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

集成 Astro 的 Font API 以管理站点的主字体，同时重构全局字体管理逻辑，将由 API 管理的字体与外部和本地字体区分开来。

新功能：
- 通过 Astro 的 Font API 配置 Inter、Zen Maru Gothic 和 JetBrains Mono，并提供相应的 CSS 变量以在整个应用中使用。

增强与改进：
- 重构全局 FontManager，将由 Astro Font API 管理的字体与外部和本地字体分离，同时保留现有的字体选择与回退行为。
- 将 Markdown、Expressive Code 和布局配置中直接导入 JetBrains Mono 以及硬编码的 `font-family` 值，替换为由 Astro 管理的代码字体支持的共享 CSS 变量。
- 精简本地 `@font-face` 生成和预加载逻辑，复用通用的辅助函数，并避免在自定义加载器中处理由 API 管理的字体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Astro's Font API for primary site fonts while refactoring global font management to distinguish API-managed fonts from external and local fonts.

New Features:
- Configure Inter, Zen Maru Gothic, and JetBrains Mono via Astro's Font API with corresponding CSS variables for use across the app.

Enhancements:
- Refactor the global FontManager to separate Astro Font API–managed fonts from external and local fonts while preserving existing selection and fallback behavior.
- Replace direct JetBrains Mono imports and hardcoded font-family values in Markdown, Expressive Code, and layout config with shared CSS variables backed by the Astro-managed code font.
- Streamline local font-face generation and preloading logic to reuse shared helpers and avoid handling API-managed fonts in custom loaders.

</details>

新特性：
- 通过 Astro 的字体 API 配置 Inter、Zen Maru Gothic 和 JetBrains Mono，实现自托管加载并提供 CSS 变量。
- 暴露字体 ID 到 CSS 变量的映射，在整个应用中用来引用由 Astro 管理的字体。

改进：
- 重构全局 FontManager，以区分 Astro 字体 API 管理的字体与外部/本地字体，同时保持现有的字体选择和回退行为不变。
- 更新 Markdown 和代码样式，使用共享的代码字体 CSS 变量，并依赖由 Astro 管理的 JetBrains Mono，而不是直接导入它。
- 调整排版配置，使 Expressive Code 及相关组件使用新的代码字体 CSS 变量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

集成 Astro 的 Font API 以管理站点的主字体，同时重构全局字体管理逻辑，将由 API 管理的字体与外部和本地字体区分开来。

新功能：
- 通过 Astro 的 Font API 配置 Inter、Zen Maru Gothic 和 JetBrains Mono，并提供相应的 CSS 变量以在整个应用中使用。

增强与改进：
- 重构全局 FontManager，将由 Astro Font API 管理的字体与外部和本地字体分离，同时保留现有的字体选择与回退行为。
- 将 Markdown、Expressive Code 和布局配置中直接导入 JetBrains Mono 以及硬编码的 `font-family` 值，替换为由 Astro 管理的代码字体支持的共享 CSS 变量。
- 精简本地 `@font-face` 生成和预加载逻辑，复用通用的辅助函数，并避免在自定义加载器中处理由 API 管理的字体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate Astro's Font API for primary site fonts while refactoring global font management to distinguish API-managed fonts from external and local fonts.

New Features:
- Configure Inter, Zen Maru Gothic, and JetBrains Mono via Astro's Font API with corresponding CSS variables for use across the app.

Enhancements:
- Refactor the global FontManager to separate Astro Font API–managed fonts from external and local fonts while preserving existing selection and fallback behavior.
- Replace direct JetBrains Mono imports and hardcoded font-family values in Markdown, Expressive Code, and layout config with shared CSS variables backed by the Astro-managed code font.
- Streamline local font-face generation and preloading logic to reuse shared helpers and avoid handling API-managed fonts in custom loaders.

</details>

</details>

</details>

</details>