### PR TITLE
fix: add footer spaces

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -53,12 +53,12 @@ if (footerConfig.enable) {
       >
     </div>
     <div class="m-0.5">
-      Powered by
+      Powered by &nbsp;
       <a
         class="transition link text-(--primary) font-medium"
         target="_blank"
         href="https://astro.build">Astro</a
-      > &
+      > & &nbsp;
       <a
         class="transition link text-(--primary) font-medium"
         target="_blank"


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<img width="1572" height="436" alt="图片" src="https://github.com/user-attachments/assets/ba38632f-b731-43f9-a616-b66ef235b61e" />


## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

Before

<img width="395" height="124" alt="图片" src="https://github.com/user-attachments/assets/95a91ae6-0ff1-4ce8-bda6-08e3342e8a48" />

After

<img width="426" height="169" alt="图片" src="https://github.com/user-attachments/assets/e8f68de7-7d08-4046-9f8b-fa6ea5cef01a" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->

## Summary by Sourcery

Bug Fixes:
- 确保页脚中 “Powered by” 文本与后面链接的框架名称之间有适当的空格

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure proper spacing between 'Powered by' text and linked framework names in the footer

</details>