### PR TITLE
refactor(footer): optimize layout with flex and gap

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -38,7 +38,7 @@ if (footerConfig.enable) {
     <div class="mb-2">
       {customFooterHtml && <div set:html={customFooterHtml} />}
     </div>
-    <div class="m-0.5 flex gap-2 justify-center">
+    <div class="m-0.5 flex gap-2 justify-center flex-wrap">
       &copy; <span id="copyright-year">{currentYear}</span>
       {profileConfig.name}. All Rights Reserved.
       <span>/</span>
@@ -54,7 +54,7 @@ if (footerConfig.enable) {
         href={url("sitemap-index.xml")}>Sitemap</a
       >
     </div>
-    <div class="m-0.5 flex gap-2 justify-center">
+    <div class="m-0.5 flex gap-2 justify-center flex-wrap">
       <span>Powered by</span>
       <a
         class="transition link text-(--primary) font-medium"

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -41,13 +41,13 @@ if (footerConfig.enable) {
     <div class="m-0.5 flex gap-2 justify-center flex-wrap">
       &copy; <span id="copyright-year">{currentYear}</span>
       {profileConfig.name}. All Rights Reserved.
-      <span>/</span>
+      <span aria-hidden="true">/</span>
       <a
         class="transition link text-(--primary) font-medium"
         target="_blank"
         href={url("rss.xml")}>RSS</a
       >
-      <span>/</span>
+      <span aria-hidden="true">/</span>
       <a
         class="transition link text-(--primary) font-medium"
         target="_blank"
@@ -61,7 +61,7 @@ if (footerConfig.enable) {
         target="_blank"
         href="https://astro.build">Astro</a
       >
-      <span>&</span>
+      <span aria-hidden="true">&</span>
       <a
         class="transition link text-(--primary) font-medium"
         target="_blank"

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -38,27 +38,30 @@ if (footerConfig.enable) {
     <div class="mb-2">
       {customFooterHtml && <div set:html={customFooterHtml} />}
     </div>
-    <div class="m-0.5">
+    <div class="m-0.5 flex gap-2 justify-center">
       &copy; <span id="copyright-year">{currentYear}</span>
-      {profileConfig.name}. All Rights Reserved. /
+      {profileConfig.name}. All Rights Reserved.
+      <span>/</span>
       <a
         class="transition link text-(--primary) font-medium"
         target="_blank"
         href={url("rss.xml")}>RSS</a
-      > /
+      >
+      <span>/</span>
       <a
         class="transition link text-(--primary) font-medium"
         target="_blank"
         href={url("sitemap-index.xml")}>Sitemap</a
       >
     </div>
-    <div class="m-0.5">
-      Powered by
+    <div class="m-0.5 flex gap-2 justify-center">
+      <span>Powered by</span>
       <a
         class="transition link text-(--primary) font-medium"
         target="_blank"
         href="https://astro.build">Astro</a
-      > &
+      >
+      <span>&</span>
       <a
         class="transition link text-(--primary) font-medium"
         target="_blank"


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

无相关 Issue

改动前
- 在我的 Firefox 上 RSS 和 Sitemap 会被拆成两行（即使足够宽）
- 部分单词和符号粘连在一起（见下图 1）

## Changes

通过 `flex` 和 `gap` 优化页脚布局，为单词和符号之间添加间距


## How To Test

`pnpm build`

`pnpm preview`

`pnpm check`

`pnpm format`


## Screenshots (if applicable)

Before

<img width="441" height="149" alt="图片" src="https://github.com/user-attachments/assets/4f03c271-6211-47f6-af7c-bf274d5ac15f" />


After

<img width="494" height="130" alt="图片" src="https://github.com/user-attachments/assets/43de5a04-f57e-45f9-a841-1b02b3140c5a" />


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->

## Summary by Sourcery

优化页脚布局，使其基于 flex，并在文本、分隔符和链接之间添加合适的间距，以提升可读性并防止在某些浏览器中出现换行问题。

Bug Fixes:
- 修复页脚链接和分隔符在特定视口宽度和浏览器中换行到多行的问题。
- 确保单词、符号和页脚链接之间具有一致的间距，避免它们看起来挤在一起。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the footer layout to be flex-based with proper spacing between text, dividers, and links to improve readability and prevent wrapping issues in some browsers.

Bug Fixes:
- Fix footer links and separators wrapping onto multiple lines on certain viewport widths and browsers.
- Ensure consistent spacing between words, symbols, and footer links to avoid them appearing stuck together.

</details>