### PR TITLE
fix: 修复 SVG 图片在灯箱中无法显示的问题

### DIFF
--- a/src/components/features/FancyboxManager.astro
+++ b/src/components/features/FancyboxManager.astro
@@ -102,7 +102,6 @@ import "@/styles/fancybox-custom.css";
   async function preprocessSvgImages() {
     const promises: Promise<void>[] = [];
 
-    // 处理 <img> 元素（文章内图片、封面等）
     document.querySelectorAll<HTMLImageElement>(IMG_SELECTOR).forEach((img) => {
       if (img.dataset.svgFixed) return;
       const src = img.getAttribute("src") || "";
@@ -111,21 +110,26 @@ import "@/styles/fancybox-custom.css";
       const fallbackH = img.naturalHeight || img.clientHeight || 900;
       promises.push(
         getSvgBlobUrl(src, fallbackW, fallbackH).then((blobUrl) => {
-          if (blobUrl) { img.src = blobUrl; img.dataset.svgFixed = "true"; }
+          if (blobUrl) {
+            img.dataset.originalSrc = src;
+            img.src = blobUrl;
+            img.dataset.svgFixed = "true";
+          }
         })
       );
     });
 
-    // 处理 data-fancybox 链接（gallery、moment 等的 data-src/href 指向 SVG）
-    document.querySelectorAll<HTMLElement>(".moment-images a[data-fancybox], [data-fancybox]:not(.moment-images a)").forEach((el) => {
+    const linkSelector = [SVG_SELECTORS[1], SVG_SELECTORS[2]].join(", ");
+    document.querySelectorAll<HTMLElement>(linkSelector).forEach((el) => {
       if (el.dataset.svgFixed) return;
-      const svgSrc = el.getAttribute("data-src") || el.getAttribute("href") || "";
+      const attr = el.hasAttribute("data-src") ? "data-src" : "href";
+      const svgSrc = el.getAttribute(attr) || "";
       if (!isSvgSrc(svgSrc)) return;
       promises.push(
         getSvgBlobUrl(svgSrc, 1600, 900).then((blobUrl) => {
           if (blobUrl) {
-            if (el.hasAttribute("data-src")) el.setAttribute("data-src", blobUrl);
-            else el.setAttribute("href", blobUrl);
+            el.dataset.originalSrc = svgSrc;
+            el.setAttribute(attr, blobUrl);
             el.dataset.svgFixed = "true";
           }
         })
@@ -170,6 +174,16 @@ import "@/styles/fancybox-custom.css";
       Fancybox.close();
       Fancybox.unbind(document.body);
     }
+    // 恢复原始 URL 并清除标记，避免 blob URL 被 revoke 后图片损坏
+    document.querySelectorAll<HTMLElement>("[data-svg-fixed]").forEach((el) => {
+      const original = el.dataset.originalSrc;
+      if (!original) return;
+      if (el instanceof HTMLImageElement) el.src = original;
+      else if (el.hasAttribute("data-src")) el.setAttribute("data-src", original);
+      else if (el.hasAttribute("href")) el.setAttribute("href", original);
+      delete el.dataset.svgFixed;
+      delete el.dataset.originalSrc;
+    });
     revokeAllSvgBlobUrls();
   }
 

--- a/src/components/features/FancyboxManager.astro
+++ b/src/components/features/FancyboxManager.astro
@@ -17,34 +17,35 @@ import "@/styles/fancybox-custom.css";
     svgBlobUrlCache.clear();
   }
 
-  async function getSvgBlobUrl(src: string, fallbackW: number, fallbackH: number): Promise<string> {
+  async function getSvgBlobUrl(src: string, fallbackW: number, fallbackH: number): Promise<string | null> {
     const cached = svgBlobUrlCache.get(src);
     if (cached) return cached;
-    const resp = await fetch(src);
-    if (!resp.ok) throw new Error(`SVG fetch failed (${resp.status}): ${src}`);
-    const svgText = await resp.text();
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(svgText, "image/svg+xml");
-    const parseError = doc.querySelector("parsererror");
-    if (parseError) throw new Error(`SVG parse error: ${src}`);
-    const svgEl = doc.querySelector("svg");
-    if (!svgEl) throw new Error(`No <svg> element found: ${src}`);
-    if (!svgEl.getAttribute("width") || !svgEl.getAttribute("height")) {
-      const vb = svgEl.getAttribute("viewBox");
-      let w = String(fallbackW), h = String(fallbackH);
-      if (vb) {
-        const parts = vb.split(/[\s,]+/);
-        if (parts.length >= 4 && Number(parts[2]) > 0 && Number(parts[3]) > 0) {
-          w = parts[2]; h = parts[3];
+    try {
+      const resp = await fetch(src);
+      if (!resp.ok) return null;
+      const svgText = await resp.text();
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(svgText, "image/svg+xml");
+      if (doc.querySelector("parsererror")) return null;
+      const svgEl = doc.querySelector("svg");
+      if (!svgEl) return null;
+      if (!svgEl.getAttribute("width") || !svgEl.getAttribute("height")) {
+        const vb = svgEl.getAttribute("viewBox");
+        let w = String(fallbackW), h = String(fallbackH);
+        if (vb) {
+          const parts = vb.split(/[\s,]+/);
+          if (parts.length >= 4 && Number(parts[2]) > 0 && Number(parts[3]) > 0) {
+            w = parts[2]; h = parts[3];
+          }
         }
+        if (!svgEl.getAttribute("width")) svgEl.setAttribute("width", w);
+        if (!svgEl.getAttribute("height")) svgEl.setAttribute("height", h);
       }
-      if (!svgEl.getAttribute("width")) svgEl.setAttribute("width", w);
-      if (!svgEl.getAttribute("height")) svgEl.setAttribute("height", h);
-    }
-    const blob = new Blob([new XMLSerializer().serializeToString(svgEl)], { type: "image/svg+xml" });
-    const blobUrl = URL.createObjectURL(blob);
-    svgBlobUrlCache.set(src, blobUrl);
-    return blobUrl;
+      const blob = new Blob([new XMLSerializer().serializeToString(svgEl)], { type: "image/svg+xml" });
+      const blobUrl = URL.createObjectURL(blob);
+      svgBlobUrlCache.set(src, blobUrl);
+      return blobUrl;
+    } catch { return null; }
   }
 
   function getCommonOptions() {
@@ -92,8 +93,6 @@ import "@/styles/fancybox-custom.css";
     };
   }
 
-  // 预处理页面上所有 SVG 图片：注入 width/height 并替换 src 为 blob URL
-  // 需在 Fancybox.bind 之前完成，否则通过缩略图导航时 SVG 无法正常显示
   async function preprocessSvgImages(imgSelector: string) {
     const promises: Promise<void>[] = [];
     document.querySelectorAll(imgSelector).forEach((el) => {
@@ -101,11 +100,15 @@ import "@/styles/fancybox-custom.css";
       if (img.dataset.svgFixed) return;
       const src = img.getAttribute("src") || "";
       if (!isSvgSrc(src)) return;
-      img.dataset.svgFixed = "true";
+      const fallbackW = img.naturalWidth || img.clientWidth || 1100;
+      const fallbackH = img.naturalHeight || img.clientHeight || 650;
       promises.push(
-        getSvgBlobUrl(src, img.clientWidth || 1100, img.clientHeight || 650)
-          .then((blobUrl) => { img.src = blobUrl; })
-          .catch((err) => { console.warn("[Fancybox] SVG preprocess failed:", err); })
+        getSvgBlobUrl(src, fallbackW, fallbackH).then((blobUrl) => {
+          if (blobUrl) {
+            img.src = blobUrl;
+            img.dataset.svgFixed = "true";
+          }
+        })
       );
     });
     await Promise.allSettled(promises);

--- a/src/components/features/FancyboxManager.astro
+++ b/src/components/features/FancyboxManager.astro
@@ -6,6 +6,12 @@ import "@/styles/fancybox-custom.css";
 
 <script>
   let Fancybox: any;
+  const IMG_SELECTOR = ".custom-md img, #post-cover img, .moment-images img";
+  const SVG_SELECTORS = [
+    IMG_SELECTOR,
+    ".moment-images a[data-fancybox]",
+    "[data-fancybox]:not(.moment-images a)",
+  ];
   const svgBlobUrlCache = new Map<string, string>();
 
   function isSvgSrc(src: string): boolean {
@@ -22,13 +28,13 @@ import "@/styles/fancybox-custom.css";
     if (cached) return cached;
     try {
       const resp = await fetch(src);
-      if (!resp.ok) return null;
+      if (!resp.ok) { console.debug("[Fancybox] SVG fetch failed:", resp.status, src); return null; }
       const svgText = await resp.text();
       const parser = new DOMParser();
       const doc = parser.parseFromString(svgText, "image/svg+xml");
-      if (doc.querySelector("parsererror")) return null;
+      if (doc.querySelector("parsererror")) { console.debug("[Fancybox] SVG parse error:", src); return null; }
       const svgEl = doc.querySelector("svg");
-      if (!svgEl) return null;
+      if (!svgEl) { console.debug("[Fancybox] No <svg> element:", src); return null; }
       if (!svgEl.getAttribute("width") || !svgEl.getAttribute("height")) {
         const vb = svgEl.getAttribute("viewBox");
         let w = String(fallbackW), h = String(fallbackH);
@@ -45,7 +51,7 @@ import "@/styles/fancybox-custom.css";
       const blobUrl = URL.createObjectURL(blob);
       svgBlobUrlCache.set(src, blobUrl);
       return blobUrl;
-    } catch { return null; }
+    } catch (err) { console.debug("[Fancybox] SVG preprocess error:", src, err); return null; }
   }
 
   function getCommonOptions() {
@@ -115,14 +121,7 @@ import "@/styles/fancybox-custom.css";
   }
 
   async function setup() {
-    const selectors = [
-      ".custom-md img, #post-cover img, .moment-images img",
-      ".moment-images a[data-fancybox]",
-      "[data-fancybox]:not(.moment-images a)"
-    ];
-
-    const hasElements = selectors.some(selector => document.querySelector(selector));
-
+    const hasElements = SVG_SELECTORS.some(selector => document.querySelector(selector));
     if (!hasElements) return;
 
     if (!Fancybox) {
@@ -131,12 +130,10 @@ import "@/styles/fancybox-custom.css";
     }
 
     const commonOptions = getCommonOptions();
-    const imgSelector = ".custom-md img, #post-cover img, .moment-images img";
 
-    // SVG 需预处理尺寸（需在 Fancybox.bind 之前完成）
-    await preprocessSvgImages(imgSelector);
+    await preprocessSvgImages(IMG_SELECTOR);
 
-    Fancybox.bind(imgSelector, {
+    Fancybox.bind(IMG_SELECTOR, {
       ...commonOptions,
       groupAll: true,
       Carousel: {

--- a/src/components/features/FancyboxManager.astro
+++ b/src/components/features/FancyboxManager.astro
@@ -92,32 +92,23 @@ import "@/styles/fancybox-custom.css";
     };
   }
 
-  function setupSvgClickHandlers(imgSelector: string) {
+  // 预处理页面上所有 SVG 图片：注入 width/height 并替换 src 为 blob URL
+  // 需在 Fancybox.bind 之前完成，否则通过缩略图导航时 SVG 无法正常显示
+  async function preprocessSvgImages(imgSelector: string) {
+    const promises: Promise<void>[] = [];
     document.querySelectorAll(imgSelector).forEach((el) => {
       const img = el as HTMLImageElement;
-      if (img.dataset.svgBound) return;
+      if (img.dataset.svgFixed) return;
       const src = img.getAttribute("src") || "";
       if (!isSvgSrc(src)) return;
-      img.dataset.svgBound = "true";
-      img.style.cursor = "zoom-in";
-      img.addEventListener("click", async (e) => {
-        if (img.dataset.svgFixed) return;
-        e.preventDefault();
-        e.stopPropagation();
-        try {
-          const blobUrl = await getSvgBlobUrl(src, img.clientWidth || 1100, img.clientHeight || 650);
-          img.dataset.svgFixed = "true";
-          const loader = new Image();
-          loader.onload = () => { img.src = blobUrl; img.click(); };
-          loader.onerror = () => { img.dataset.svgFixed = ""; img.click(); };
-          loader.src = blobUrl;
-        } catch (err) {
-          console.warn("[Fancybox] SVG preprocessing failed, falling back to default:", err);
-          img.dataset.svgFixed = "";
-          img.click();
-        }
-      });
+      img.dataset.svgFixed = "true";
+      promises.push(
+        getSvgBlobUrl(src, img.clientWidth || 1100, img.clientHeight || 650)
+          .then((blobUrl) => { img.src = blobUrl; })
+          .catch((err) => { console.warn("[Fancybox] SVG preprocess failed:", err); })
+      );
     });
+    await Promise.allSettled(promises);
   }
 
   async function setup() {
@@ -139,8 +130,8 @@ import "@/styles/fancybox-custom.css";
     const commonOptions = getCommonOptions();
     const imgSelector = ".custom-md img, #post-cover img, .moment-images img";
 
-    // SVG 需预处理尺寸（需在 Fancybox.bind 之前注册）
-    setupSvgClickHandlers(imgSelector);
+    // SVG 需预处理尺寸（需在 Fancybox.bind 之前完成）
+    await preprocessSvgImages(imgSelector);
 
     Fancybox.bind(imgSelector, {
       ...commonOptions,

--- a/src/components/features/FancyboxManager.astro
+++ b/src/components/features/FancyboxManager.astro
@@ -6,11 +6,15 @@ import "@/styles/fancybox-custom.css";
 
 <script>
   let Fancybox: any;
-  // SVG 缓存：原始 src → 包含 width/height 的 blob URL
   const svgBlobUrlCache = new Map<string, string>();
 
   function isSvgSrc(src: string): boolean {
     return !!src && (src.match(/\.svg($|\?)/i) !== null || src.match(/[?&]f=svg/i) !== null);
+  }
+
+  function revokeAllSvgBlobUrls() {
+    for (const url of svgBlobUrlCache.values()) URL.revokeObjectURL(url);
+    svgBlobUrlCache.clear();
   }
 
   async function getSvgBlobUrl(src: string): Promise<string> {
@@ -18,23 +22,22 @@ import "@/styles/fancybox-custom.css";
     if (cached) return cached;
     const resp = await fetch(src);
     if (!resp.ok) throw new Error(`fetch failed: ${resp.status}`);
-    let svgText = await resp.text();
-    const match = svgText.match(/<svg([^>]*)>/);
-    if (match) {
-      const attrs = match[1];
-      const hasWidth = /\bwidth\s*=/i.test(attrs);
-      const hasHeight = /\bheight\s*=/i.test(attrs);
-      if (!hasWidth || !hasHeight) {
-        const vbMatch = attrs.match(/viewBox\s*=\s*["']?\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/i);
-        const w = vbMatch ? vbMatch[3] : "1100";
-        const h = vbMatch ? vbMatch[4] : "650";
-        let newAttrs = attrs;
-        if (!hasWidth) newAttrs += ` width="${w}"`;
-        if (!hasHeight) newAttrs += ` height="${h}"`;
-        svgText = svgText.replace(match[0], `<svg${newAttrs}>`);
+    const svgText = await resp.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(svgText, "image/svg+xml");
+    const svgEl = doc.querySelector("svg");
+    if (!svgEl) throw new Error("invalid SVG");
+    if (!svgEl.getAttribute("width") || !svgEl.getAttribute("height")) {
+      const vb = svgEl.getAttribute("viewBox");
+      let w = "1100", h = "650";
+      if (vb) {
+        const parts = vb.split(/[\s,]+/);
+        if (parts.length >= 4) { w = parts[2]; h = parts[3]; }
       }
+      if (!svgEl.getAttribute("width")) svgEl.setAttribute("width", w);
+      if (!svgEl.getAttribute("height")) svgEl.setAttribute("height", h);
     }
-    const blob = new Blob([svgText], { type: "image/svg+xml" });
+    const blob = new Blob([new XMLSerializer().serializeToString(svgEl)], { type: "image/svg+xml" });
     const blobUrl = URL.createObjectURL(blob);
     svgBlobUrlCache.set(src, blobUrl);
     return blobUrl;
@@ -161,6 +164,7 @@ import "@/styles/fancybox-custom.css";
       Fancybox.close();
       Fancybox.unbind(document.body);
     }
+    revokeAllSvgBlobUrls();
   }
 
   // 初始化

--- a/src/components/features/FancyboxManager.astro
+++ b/src/components/features/FancyboxManager.astro
@@ -108,17 +108,13 @@ import "@/styles/fancybox-custom.css";
           const blobUrl = await getSvgBlobUrl(src, img.clientWidth || 1100, img.clientHeight || 650);
           img.dataset.svgFixed = "true";
           const loader = new Image();
-          const openFancybox = () => {
-            img.src = blobUrl;
-            Fancybox.fromNodes([img]);
-          };
-          loader.onload = openFancybox;
-          loader.onerror = openFancybox;
+          loader.onload = () => { img.src = blobUrl; img.click(); };
+          loader.onerror = () => { img.dataset.svgFixed = ""; img.click(); };
           loader.src = blobUrl;
         } catch (err) {
           console.warn("[Fancybox] SVG preprocessing failed, falling back to default:", err);
-          img.dataset.svgFixed = "true";
-          Fancybox.fromNodes([img]);
+          img.dataset.svgFixed = "";
+          img.click();
         }
       });
     });

--- a/src/components/features/FancyboxManager.astro
+++ b/src/components/features/FancyboxManager.astro
@@ -7,15 +7,17 @@ import "@/styles/fancybox-custom.css";
 <script>
   let Fancybox: any;
   const IMG_SELECTOR = ".custom-md img, #post-cover img, .moment-images img";
-  const SVG_SELECTORS = [
-    IMG_SELECTOR,
-    ".moment-images a[data-fancybox]",
-    "[data-fancybox]:not(.moment-images a)",
-  ];
+  const LINK_SELECTOR = ".moment-images a[data-fancybox], [data-fancybox]:not(.moment-images a)";
   const svgBlobUrlCache = new Map<string, string>();
 
   function isSvgSrc(src: string): boolean {
-    return !!src && (src.match(/\.svg($|\?)/i) !== null || src.match(/[?&]f=svg/i) !== null);
+    if (!src) return false;
+    try {
+      const url = new URL(src, location.href);
+      if (url.pathname.toLowerCase().endsWith(".svg")) return true;
+      if (url.searchParams.get("f")?.toLowerCase() === "svg") return true;
+    } catch { return false; }
+    return false;
   }
 
   function revokeAllSvgBlobUrls() {
@@ -119,8 +121,7 @@ import "@/styles/fancybox-custom.css";
       );
     });
 
-    const linkSelector = [SVG_SELECTORS[1], SVG_SELECTORS[2]].join(", ");
-    document.querySelectorAll<HTMLElement>(linkSelector).forEach((el) => {
+    document.querySelectorAll<HTMLElement>(LINK_SELECTOR).forEach((el) => {
       if (el.dataset.svgFixed) return;
       const attr = el.hasAttribute("data-src") ? "data-src" : "href";
       const svgSrc = el.getAttribute(attr) || "";
@@ -140,8 +141,7 @@ import "@/styles/fancybox-custom.css";
   }
 
   async function setup() {
-    const hasElements = SVG_SELECTORS.some(selector => document.querySelector(selector));
-    if (!hasElements) return;
+    if (!document.querySelector(IMG_SELECTOR) && !document.querySelector(LINK_SELECTOR)) return;
 
     if (!Fancybox) {
       const mod = await import("@fancyapps/ui");
@@ -161,12 +161,10 @@ import "@/styles/fancybox-custom.css";
       },
     });
 
-    Fancybox.bind(".moment-images a[data-fancybox]", {
+    Fancybox.bind(LINK_SELECTOR, {
       ...commonOptions,
       source: (el: any) => el.getAttribute("data-src") || el.getAttribute("href"),
     });
-
-    Fancybox.bind("[data-fancybox]:not(.moment-images a)", commonOptions);
   }
 
   function cleanupFancybox() {

--- a/src/components/features/FancyboxManager.astro
+++ b/src/components/features/FancyboxManager.astro
@@ -99,24 +99,39 @@ import "@/styles/fancybox-custom.css";
     };
   }
 
-  async function preprocessSvgImages(imgSelector: string) {
+  async function preprocessSvgImages() {
     const promises: Promise<void>[] = [];
-    document.querySelectorAll(imgSelector).forEach((el) => {
-      const img = el as HTMLImageElement;
+
+    // 处理 <img> 元素（文章内图片、封面等）
+    document.querySelectorAll<HTMLImageElement>(IMG_SELECTOR).forEach((img) => {
       if (img.dataset.svgFixed) return;
       const src = img.getAttribute("src") || "";
       if (!isSvgSrc(src)) return;
-      const fallbackW = img.naturalWidth || img.clientWidth || 1100;
-      const fallbackH = img.naturalHeight || img.clientHeight || 650;
+      const fallbackW = img.naturalWidth || img.clientWidth || 1600;
+      const fallbackH = img.naturalHeight || img.clientHeight || 900;
       promises.push(
         getSvgBlobUrl(src, fallbackW, fallbackH).then((blobUrl) => {
+          if (blobUrl) { img.src = blobUrl; img.dataset.svgFixed = "true"; }
+        })
+      );
+    });
+
+    // 处理 data-fancybox 链接（gallery、moment 等的 data-src/href 指向 SVG）
+    document.querySelectorAll<HTMLElement>(".moment-images a[data-fancybox], [data-fancybox]:not(.moment-images a)").forEach((el) => {
+      if (el.dataset.svgFixed) return;
+      const svgSrc = el.getAttribute("data-src") || el.getAttribute("href") || "";
+      if (!isSvgSrc(svgSrc)) return;
+      promises.push(
+        getSvgBlobUrl(svgSrc, 1600, 900).then((blobUrl) => {
           if (blobUrl) {
-            img.src = blobUrl;
-            img.dataset.svgFixed = "true";
+            if (el.hasAttribute("data-src")) el.setAttribute("data-src", blobUrl);
+            else el.setAttribute("href", blobUrl);
+            el.dataset.svgFixed = "true";
           }
         })
       );
     });
+
     await Promise.allSettled(promises);
   }
 
@@ -131,7 +146,7 @@ import "@/styles/fancybox-custom.css";
 
     const commonOptions = getCommonOptions();
 
-    await preprocessSvgImages(IMG_SELECTOR);
+    await preprocessSvgImages();
 
     Fancybox.bind(IMG_SELECTOR, {
       ...commonOptions,

--- a/src/components/features/FancyboxManager.astro
+++ b/src/components/features/FancyboxManager.astro
@@ -17,22 +17,26 @@ import "@/styles/fancybox-custom.css";
     svgBlobUrlCache.clear();
   }
 
-  async function getSvgBlobUrl(src: string): Promise<string> {
+  async function getSvgBlobUrl(src: string, fallbackW: number, fallbackH: number): Promise<string> {
     const cached = svgBlobUrlCache.get(src);
     if (cached) return cached;
     const resp = await fetch(src);
-    if (!resp.ok) throw new Error(`fetch failed: ${resp.status}`);
+    if (!resp.ok) throw new Error(`SVG fetch failed (${resp.status}): ${src}`);
     const svgText = await resp.text();
     const parser = new DOMParser();
     const doc = parser.parseFromString(svgText, "image/svg+xml");
+    const parseError = doc.querySelector("parsererror");
+    if (parseError) throw new Error(`SVG parse error: ${src}`);
     const svgEl = doc.querySelector("svg");
-    if (!svgEl) throw new Error("invalid SVG");
+    if (!svgEl) throw new Error(`No <svg> element found: ${src}`);
     if (!svgEl.getAttribute("width") || !svgEl.getAttribute("height")) {
       const vb = svgEl.getAttribute("viewBox");
-      let w = "1100", h = "650";
+      let w = String(fallbackW), h = String(fallbackH);
       if (vb) {
         const parts = vb.split(/[\s,]+/);
-        if (parts.length >= 4) { w = parts[2]; h = parts[3]; }
+        if (parts.length >= 4 && Number(parts[2]) > 0 && Number(parts[3]) > 0) {
+          w = parts[2]; h = parts[3];
+        }
       }
       if (!svgEl.getAttribute("width")) svgEl.setAttribute("width", w);
       if (!svgEl.getAttribute("height")) svgEl.setAttribute("height", h);
@@ -96,26 +100,26 @@ import "@/styles/fancybox-custom.css";
       if (!isSvgSrc(src)) return;
       img.dataset.svgBound = "true";
       img.style.cursor = "zoom-in";
-      // SVG 无固有尺寸，需要先注入 width/height 再交给 Fancybox
       img.addEventListener("click", async (e) => {
         if (img.dataset.svgFixed) return;
         e.preventDefault();
         e.stopPropagation();
         try {
-          const blobUrl = await getSvgBlobUrl(src);
+          const blobUrl = await getSvgBlobUrl(src, img.clientWidth || 1100, img.clientHeight || 650);
           img.dataset.svgFixed = "true";
-          // 预加载 blob URL，等解码完成后再触发 Fancybox
           const loader = new Image();
-          loader.onload = () => {
+          const openFancybox = () => {
             img.src = blobUrl;
-            img.click();
+            Fancybox.fromNodes([img]);
           };
-          loader.onerror = () => {
-            img.src = blobUrl;
-            img.click();
-          };
+          loader.onload = openFancybox;
+          loader.onerror = openFancybox;
           loader.src = blobUrl;
-        } catch { return; }
+        } catch (err) {
+          console.warn("[Fancybox] SVG preprocessing failed, falling back to default:", err);
+          img.dataset.svgFixed = "true";
+          Fancybox.fromNodes([img]);
+        }
       });
     });
   }

--- a/src/components/features/FancyboxManager.astro
+++ b/src/components/features/FancyboxManager.astro
@@ -6,27 +6,42 @@ import "@/styles/fancybox-custom.css";
 
 <script>
   let Fancybox: any;
+  // SVG 缓存：原始 src → 包含 width/height 的 blob URL
+  const svgBlobUrlCache = new Map<string, string>();
 
-  async function setup() {
-    const selectors = [
-      ".custom-md img, #post-cover img, .moment-images img",
-      ".moment-images a[data-fancybox]",
-      "[data-fancybox]:not(.moment-images a)"
-    ];
+  function isSvgSrc(src: string): boolean {
+    return !!src && (src.match(/\.svg($|\?)/i) !== null || src.match(/[?&]f=svg/i) !== null);
+  }
 
-    // 检查页面是否存在需要 Fancybox 的元素
-    const hasElements = selectors.some(selector => document.querySelector(selector));
-
-    if (!hasElements) return;
-
-    // 动态导入资源
-    if (!Fancybox) {
-      const mod = await import("@fancyapps/ui");
-      Fancybox = mod.Fancybox;
+  async function getSvgBlobUrl(src: string): Promise<string> {
+    const cached = svgBlobUrlCache.get(src);
+    if (cached) return cached;
+    const resp = await fetch(src);
+    if (!resp.ok) throw new Error(`fetch failed: ${resp.status}`);
+    let svgText = await resp.text();
+    const match = svgText.match(/<svg([^>]*)>/);
+    if (match) {
+      const attrs = match[1];
+      const hasWidth = /\bwidth\s*=/i.test(attrs);
+      const hasHeight = /\bheight\s*=/i.test(attrs);
+      if (!hasWidth || !hasHeight) {
+        const vbMatch = attrs.match(/viewBox\s*=\s*["']?\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/i);
+        const w = vbMatch ? vbMatch[3] : "1100";
+        const h = vbMatch ? vbMatch[4] : "650";
+        let newAttrs = attrs;
+        if (!hasWidth) newAttrs += ` width="${w}"`;
+        if (!hasHeight) newAttrs += ` height="${h}"`;
+        svgText = svgText.replace(match[0], `<svg${newAttrs}>`);
+      }
     }
+    const blob = new Blob([svgText], { type: "image/svg+xml" });
+    const blobUrl = URL.createObjectURL(blob);
+    svgBlobUrlCache.set(src, blobUrl);
+    return blobUrl;
+  }
 
-    // 通用配置
-    const commonOptions = {
+  function getCommonOptions() {
+    return {
       Thumbs: {
         autoStart: true,
         showOnStart: "yes",
@@ -68,9 +83,63 @@ import "@/styles/fancybox-custom.css";
       },
       caption: false,
     };
+  }
 
-    // 绑定图片
-    Fancybox.bind(".custom-md img, #post-cover img, .moment-images img", {
+  function setupSvgClickHandlers(imgSelector: string) {
+    document.querySelectorAll(imgSelector).forEach((el) => {
+      const img = el as HTMLImageElement;
+      if (img.dataset.svgBound) return;
+      const src = img.getAttribute("src") || "";
+      if (!isSvgSrc(src)) return;
+      img.dataset.svgBound = "true";
+      img.style.cursor = "zoom-in";
+      // SVG 无固有尺寸，需要先注入 width/height 再交给 Fancybox
+      img.addEventListener("click", async (e) => {
+        if (img.dataset.svgFixed) return;
+        e.preventDefault();
+        e.stopPropagation();
+        try {
+          const blobUrl = await getSvgBlobUrl(src);
+          img.dataset.svgFixed = "true";
+          // 预加载 blob URL，等解码完成后再触发 Fancybox
+          const loader = new Image();
+          loader.onload = () => {
+            img.src = blobUrl;
+            img.click();
+          };
+          loader.onerror = () => {
+            img.src = blobUrl;
+            img.click();
+          };
+          loader.src = blobUrl;
+        } catch { return; }
+      });
+    });
+  }
+
+  async function setup() {
+    const selectors = [
+      ".custom-md img, #post-cover img, .moment-images img",
+      ".moment-images a[data-fancybox]",
+      "[data-fancybox]:not(.moment-images a)"
+    ];
+
+    const hasElements = selectors.some(selector => document.querySelector(selector));
+
+    if (!hasElements) return;
+
+    if (!Fancybox) {
+      const mod = await import("@fancyapps/ui");
+      Fancybox = mod.Fancybox;
+    }
+
+    const commonOptions = getCommonOptions();
+    const imgSelector = ".custom-md img, #post-cover img, .moment-images img";
+
+    // SVG 需预处理尺寸（需在 Fancybox.bind 之前注册）
+    setupSvgClickHandlers(imgSelector);
+
+    Fancybox.bind(imgSelector, {
       ...commonOptions,
       groupAll: true,
       Carousel: {
@@ -79,13 +148,11 @@ import "@/styles/fancybox-custom.css";
       },
     });
 
-    // 绑定链接
     Fancybox.bind(".moment-images a[data-fancybox]", {
       ...commonOptions,
       source: (el: any) => el.getAttribute("data-src") || el.getAttribute("href"),
     });
 
-    // 绑定其他
     Fancybox.bind("[data-fancybox]:not(.moment-images a)", commonOptions);
   }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

#439

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

</details>

</details>

Bug 修复：
- 通过规范 SVG 图像的尺寸，并在打开 Fancybox 之前通过 blob URL 加载它们，确保 SVG 图像能在灯箱中正确显示。

增强功能：
- 重构 Fancybox 的设置流程，复用共享的配置助手函数，集中管理图片选择器处理逻辑，并在销毁时清理临时 SVG blob URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

Bug 修复：
- 通过在 Fancybox 打开前规范化 SVG 图像的尺寸并通过 blob URL 加载它们，修复 SVG 图像在灯箱中无法显示的问题。

增强优化：
- 重构 Fancybox 的初始化流程，通过辅助函数复用共享配置，并集中处理图像选择器逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

</details>

</details>

Bug 修复：
- 通过规范 SVG 图像的尺寸，并在打开 Fancybox 之前通过 blob URL 加载它们，确保 SVG 图像能在灯箱中正确显示。

增强功能：
- 重构 Fancybox 的设置流程，复用共享的配置助手函数，集中管理图片选择器处理逻辑，并在销毁时清理临时 SVG blob URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

Bug 修复：
- 在将 SVG 绑定到 Fancybox 之前，先对其进行预处理：规范化其尺寸，并通过 blob URL 加载，这样它们就能在灯箱中正确渲染。
- 在 Fancybox 被销毁时清理临时的 SVG blob URL，防止出现失效的图片链接。

增强改进：
- 重构 Fancybox 的初始化流程，通过辅助工具集中管理通用配置和图片选择器处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

Bug 修复：
- 确保对 SVG 图片进行预处理，规范其尺寸并通过 blob URL 加载，使其在 Fancybox 中能够正确渲染。
- 在销毁 Fancybox 时清理临时的 SVG blob URL，避免出现无效的图片引用。

改进：
- 将通用的 Fancybox 配置选项提取到一个辅助方法中，以便在各个绑定中复用统一配置。
- 统一图片选择器的使用方式，并在将图片绑定到 Fancybox 之前增加对 SVG 的预处理步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 Fancybox 生命周期前后对 SVG 图像进行预处理和还原，修复 SVG 图像在 Fancybox 灯箱中无法渲染的问题。

Bug 修复：
- 确保在文章和动态中使用的 SVG 图像在尺寸上进行规范化，并通过 blob URL 加载，使其能够在 Fancybox 中正确渲染。
- 在 Fancybox 被销毁时恢复原始 SVG URL，并撤销临时 blob URL，以避免图像损坏或对象 URL 泄漏。

增强功能：
- 引入共享的图像选择器以及用于通用 Fancybox 配置的辅助方法，以集中并复用相关的初始化逻辑。
- 在绑定 Fancybox 之前，为 `<img>` 元素和与 Fancybox 关联的元素中的 SVG 源添加预处理步骤，从而提升图像处理的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix SVG images not rendering in Fancybox lightbox by preprocessing and restoring them around Fancybox lifecycle.

Bug Fixes:
- Ensure SVG images used in posts and moments are normalized for dimensions and loaded via blob URLs so they render correctly in Fancybox.
- Restore original SVG URLs and revoke temporary blob URLs when Fancybox is destroyed to avoid broken images or leaked object URLs.

Enhancements:
- Introduce shared image selectors and a helper for common Fancybox configuration to centralize and reuse setup logic.
- Add a preprocessing step for SVG sources in both <img> elements and Fancybox-linked elements before binding Fancybox, improving consistency of image handling.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>