### PR TITLE
fix(site-info): detect EdgeOne Pages and ESA Pages build platforms and support custom platform labels

### DIFF
--- a/src/components/widget/SiteInfo.astro
+++ b/src/components/widget/SiteInfo.astro
@@ -8,6 +8,7 @@ import { licenseConfig, siteConfig } from "@/config";
 import I18nKey from "@/i18n/i18nKey";
 import { i18n } from "@/i18n/translation";
 import type { WidgetComponentConfig } from "@/types/config";
+import { detectBuildPlatform } from "@/utils/build-platform";
 import { formatDateI18nWithTime } from "@/utils/date-utils";
 
 interface Props {
@@ -56,11 +57,13 @@ const buildTime = formatDateI18nWithTime(new Date());
 // 构建平台检测（使用 ci-info 自动识别 CI 环境）
 const unknownBuildPlatform =
 	widgetConfig?.specificConfig?.siteInfo?.unknownBuildPlatform || "Unknown CI";
-const buildPlatform = ci.isCI
-	? ci.name || unknownBuildPlatform
-	: import.meta.env.DEV
-		? "Local Dev"
-		: "Local";
+const buildPlatform = detectBuildPlatform({
+	env: process.env,
+	isCI: ci.isCI,
+	ciName: ci.name,
+	isDev: import.meta.env.DEV,
+	unknownBuildPlatform,
+});
 
 // 系统信息（平台 + 架构）
 const platformMap: Record<string, string> = {

--- a/src/utils/build-platform.ts
+++ b/src/utils/build-platform.ts
@@ -1,0 +1,65 @@
+type DetectBuildPlatformOptions = {
+	env: Record<string, string | undefined>;
+	isCI: boolean;
+	ciName?: string | null;
+	isDev?: boolean;
+	unknownBuildPlatform?: string;
+};
+
+const BUILD_PLATFORM_OVERRIDE_KEY = "FIREFLY_BUILD_PLATFORM";
+
+function hasNonEmptyEnv(
+	env: Record<string, string | undefined>,
+	key: string,
+): boolean {
+	const value = env[key];
+	return typeof value === "string" && value.trim() !== "";
+}
+
+function envUrlHostEquals(
+	env: Record<string, string | undefined>,
+	key: string,
+	expectedHost: string,
+): boolean {
+	const value = env[key];
+	if (typeof value !== "string" || value.trim() === "") {
+		return false;
+	}
+
+	try {
+		return new URL(value).host.toLowerCase() === expectedHost.toLowerCase();
+	} catch {
+		return false;
+	}
+}
+
+export function detectBuildPlatform({
+	env,
+	isCI,
+	ciName,
+	isDev = false,
+	unknownBuildPlatform = "Unknown CI",
+}: DetectBuildPlatformOptions): string {
+	const overrideValue = env[BUILD_PLATFORM_OVERRIDE_KEY];
+	if (typeof overrideValue === "string" && overrideValue.trim() !== "") {
+		return overrideValue.trim();
+	}
+
+	if (ciName?.trim()) {
+		return ciName.trim();
+	}
+
+	if (hasNonEmptyEnv(env, "EDGEONE_PROJECT_ID")) {
+		return "EdgeOne Pages";
+	}
+
+	if (envUrlHostEquals(env, "er_address", "build-script.esa.ialicdn.com")) {
+		return "ESA Pages";
+	}
+
+	if (isCI) {
+		return unknownBuildPlatform;
+	}
+
+	return isDev ? "Local Dev" : "Local";
+}

--- a/src/utils/build-platform.ts
+++ b/src/utils/build-platform.ts
@@ -58,7 +58,7 @@ export function detectBuildPlatform({
 	if (envUrlHostEquals(env, "er_address", "build-script.esa.ialicdn.com")) {
 		return "ESA Pages";
 	}
-	
+
 	if (isCI) {
 		return unknownBuildPlatform;
 	}

--- a/src/utils/build-platform.ts
+++ b/src/utils/build-platform.ts
@@ -1,0 +1,68 @@
+type DetectBuildPlatformOptions = {
+	env: Record<string, string | undefined>;
+	isCI: boolean;
+	ciName?: string | null;
+	isDev?: boolean;
+	unknownBuildPlatform?: string;
+};
+
+const BUILD_PLATFORM_OVERRIDE_KEY = "FIREFLY_BUILD_PLATFORM";
+
+function hasNonEmptyEnv(
+	env: Record<string, string | undefined>,
+	key: string,
+): boolean {
+	const value = env[key];
+	return typeof value === "string" && value.trim() !== "";
+}
+
+function envUrlHostEquals(
+	env: Record<string, string | undefined>,
+	key: string,
+	expectedHost: string,
+): boolean {
+	const value = env[key];
+	if (typeof value !== "string" || value.trim() === "") {
+		return false;
+	}
+
+	try {
+		// ESA 当前构建环境里没有平台专属键名，改为用稳定的内部脚本 host 做识别
+		return new URL(value).host.toLowerCase() === expectedHost.toLowerCase();
+	} catch {
+		return false;
+	}
+}
+
+export function detectBuildPlatform({
+	env,
+	isCI,
+	ciName,
+	isDev = false,
+	unknownBuildPlatform = "Unknown CI",
+}: DetectBuildPlatformOptions): string {
+	const overrideValue = env[BUILD_PLATFORM_OVERRIDE_KEY];
+	if (typeof overrideValue === "string" && overrideValue.trim() !== "") {
+		// 显式覆盖优先于所有自动识别结果，方便在部署平台直接指定展示名称
+		return overrideValue.trim();
+	}
+
+	if (ciName?.trim()) {
+		return ciName.trim();
+	}
+
+	if (hasNonEmptyEnv(env, "EDGEONE_PROJECT_ID")) {
+		return "EdgeOne Pages";
+	}
+
+	if (envUrlHostEquals(env, "er_address", "build-script.esa.ialicdn.com")) {
+		return "ESA Pages";
+	}
+
+	if (isCI) {
+		// 仍然保留上游原有的未知平台回退文案能力
+		return unknownBuildPlatform;
+	}
+
+	return isDev ? "Local Dev" : "Local";
+}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Changes

修复 `SiteInfo` 组件在 `ci-info` 无法识别 EdgeOne Pages / ESA Pages 时只显示 `Unknown CI` 的问题，并加入不同平台部署的自定义命名功能。

本次改动：
- 新增 `FIREFLY_BUILD_PLATFORM` 环境变量用于自定义不同部署平台的名字并且优先级最高（默认为空，不启用，继续使用ci.name）
- 保留原有 `ci-info` 识别逻辑
- 补充 EdgeOne Pages 识别：（用脚本在构建中抓取到的稳定的环境变量）
  - `EDGEONE_PROJECT_ID`
- 补充 ESA Pages 识别：（用脚本在构建中抓取到的稳定的环境变量）
  - `er_address` host 为 `build-script.esa.ialicdn.com`
- 保留原有 `unknownBuildPlatform` 逻辑及其统一的自定义命名

## How To Test

已在以下环境中验证：

- EdgeOne Pages
- ESA Pages
- Cloudflare Workers
- Netlify
- Vercel
- 本地开发环境Local Dev

## Screenshots (if applicable)
1.EdgeOne Pages和ESA Pages的补充识别（无自定义）：
脚本抓取的日志显示：
<img width="445" height="130" alt="image" src="https://github.com/user-attachments/assets/bfad6af8-86cc-48d1-9aa6-4eb491f336e8" />
<img width="766" height="288" alt="image" src="https://github.com/user-attachments/assets/32889db3-469e-48ec-9af8-10c7b9ef99b2" />

实际效果：
<img width="336" height="204" alt="image" src="https://github.com/user-attachments/assets/1413a37d-30cf-4709-91ae-f0ac319b4da3" />
<img width="335" height="212" alt="image" src="https://github.com/user-attachments/assets/0d91eed0-20f8-48fd-b35f-84ede0aa8ebb" />


2.环境变量自定义名称（FIREFLY_BUILD_PLATFORM）：
在对应平台加入环境变量（以EdgeOne为例，其他平台操作类似）：
<img width="590" height="126" alt="image" src="https://github.com/user-attachments/assets/2c04c959-3d0a-44e2-a5e1-5992f0ea2c2b" />
实际效果：
<img width="334" height="210" alt="image" src="https://github.com/user-attachments/assets/eb8f1fc5-f545-4515-9ceb-4119fd113ec4" />
<img width="324" height="198" alt="image" src="https://github.com/user-attachments/assets/da0539d1-cfab-4415-80bc-5bd1eb453021" />
<img width="336" height="212" alt="image" src="https://github.com/user-attachments/assets/f5801ec9-709c-4278-8433-b7784d255575" />
<img width="338" height="206" alt="image" src="https://github.com/user-attachments/assets/195583ac-07d4-4cbe-8d4e-88ce7e0c5d89" />
<img width="328" height="219" alt="image" src="https://github.com/user-attachments/assets/25c71575-be8a-47a4-9874-901feeb20911" />
<img width="331" height="215" alt="image" src="https://github.com/user-attachments/assets/e1b0693e-c836-472f-80af-3fb7dc7f2e65" />

## 由 Sourcery 提供的摘要

通过可复用的实用工具检测构建平台，并扩展对更多环境的支持。

错误修复：
- 通过改进构建平台检测机制，确保在未识别的平台上运行时，SiteInfo 小部件不再显示通用的 Unknown CI 标签。

增强内容：
- 引入一个 build-platform 工具，用于集中处理构建平台解析逻辑，包括 CI 检测以及本地/开发环境。
- 基于稳定的环境变量，新增对 EdgeOne Pages 和 ESA Pages 部署的识别支持。
- 允许通过 FIREFLY_BUILD_PLATFORM 环境变量覆盖检测到的构建平台名称，以实现自定义平台标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 SiteInfo 小组件中的构建平台检测，并将逻辑集中到可复用的工具中。

Bug Fixes（错误修复）:
- 确保在 EdgeOne Pages 和 ESA Pages 上，SiteInfo 显示有意义的构建平台名称，而不是总是回退为 Unknown CI。

Enhancements（功能增强）:
- 引入一个 build-platform 工具，在不同环境（包括 CI 和本地开发）中封装构建平台检测逻辑。
- 基于稳定的环境变量，增加对 EdgeOne Pages 和 ESA Pages 的检测。
- 支持通过优先级最高的环境变量 `FIREFLY_BUILD_PLATFORM` 来设置自定义构建平台标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve build platform detection in the SiteInfo widget and centralize the logic in a reusable utility.

Bug Fixes:
- Ensure SiteInfo shows a meaningful build platform name instead of always falling back to Unknown CI on EdgeOne Pages and ESA Pages.

Enhancements:
- Introduce a build-platform utility to encapsulate build platform detection across environments, including CI and local development.
- Add detection for EdgeOne Pages and ESA Pages based on stable environment variables.
- Support custom build platform labels via the FIREFLY_BUILD_PLATFORM environment variable with highest precedence.

</details>

</details>