### PR TITLE
feat: 实现黑暗模式圆形扩散动画

### DIFF
--- a/src/components/controls/LightDarkSwitch.svelte
+++ b/src/components/controls/LightDarkSwitch.svelte
@@ -11,6 +11,7 @@ import {
 	applyThemeToDocument,
 	getStoredTheme,
 	setTheme,
+	setThemeWithAnimation,
 } from "@/utils/setting-utils";
 
 // Define Swup type for window object
@@ -27,9 +28,16 @@ type WindowWithSwup = Window & { swup?: SwupInstance };
 let mode: LIGHT_DARK_MODE = $state(LIGHT_MODE);
 let displayedMode: LIGHT_DARK_MODE = $state(LIGHT_MODE); // 显示的实际主题（在system模式下会随系统变化）
 
-function switchScheme(newMode: LIGHT_DARK_MODE) {
+// 切换主题模式；用户点击触发时传入鼠标坐标，用于圆形扩散动画的起点
+function switchScheme(newMode: LIGHT_DARK_MODE, event?: MouseEvent) {
 	mode = newMode;
-	setTheme(newMode);
+	if (event) {
+		// 菜单点击切换时使用 View Transitions 圆形扩散动画
+		setThemeWithAnimation(newMode, event.clientX, event.clientY);
+	} else {
+		// 程序化切换或无坐标来源时保持原来的直接切换逻辑
+		setTheme(newMode);
+	}
 	updateDisplayedMode();
 }
 
@@ -130,7 +138,7 @@ onMount(() => {
                 role="menuitem"
                 isActive={mode === LIGHT_MODE}
                 isLast={false}
-                onclick={() => switchScheme(LIGHT_MODE)}
+                onclick={(event) => switchScheme(LIGHT_MODE, event)}
             >
                 <Icon icon="material-symbols:wb-sunny-outline-rounded" class="text-[1.25rem] mr-3"></Icon>
                 {i18n(I18nKey.lightMode)}
@@ -139,7 +147,7 @@ onMount(() => {
                 role="menuitem"
                 isActive={mode === DARK_MODE}
                 isLast={false}
-                onclick={() => switchScheme(DARK_MODE)}
+                onclick={(event) => switchScheme(DARK_MODE, event)}
             >
                 <Icon icon="material-symbols:dark-mode-outline-rounded" class="text-[1.25rem] mr-3"></Icon>
                 {i18n(I18nKey.darkMode)}
@@ -148,7 +156,7 @@ onMount(() => {
                 role="menuitem"
                 isActive={mode === SYSTEM_MODE}
                 isLast={true}
-                onclick={() => switchScheme(SYSTEM_MODE)}
+                onclick={(event) => switchScheme(SYSTEM_MODE, event)}
             >
                 <Icon icon="material-symbols:brightness-auto-outline-rounded" class="text-[1.25rem] mr-3"></Icon>
                 {i18n(I18nKey.systemMode)}

--- a/src/components/controls/LightDarkSwitch.svelte
+++ b/src/components/controls/LightDarkSwitch.svelte
@@ -28,12 +28,35 @@ type WindowWithSwup = Window & { swup?: SwupInstance };
 let mode: LIGHT_DARK_MODE = $state(LIGHT_MODE);
 let displayedMode: LIGHT_DARK_MODE = $state(LIGHT_MODE); // 显示的实际主题（在system模式下会随系统变化）
 
+// 获取动画起点：鼠标点击使用点击坐标，键盘触发使用当前菜单项中心点
+function getEventOrigin(event?: MouseEvent): { x: number; y: number } | undefined {
+	if (!event) {
+		return undefined;
+	}
+
+	if (event.detail > 0 && (event.clientX > 0 || event.clientY > 0)) {
+		return { x: event.clientX, y: event.clientY };
+	}
+
+	const target = event.currentTarget as HTMLElement | null;
+	if (!target) {
+		return undefined;
+	}
+
+	const rect = target.getBoundingClientRect();
+	return {
+		x: rect.left + rect.width / 2,
+		y: rect.top + rect.height / 2,
+	};
+}
+
 // 切换主题模式；用户点击触发时传入鼠标坐标，用于圆形扩散动画的起点
 function switchScheme(newMode: LIGHT_DARK_MODE, event?: MouseEvent) {
 	mode = newMode;
-	if (event) {
+	const origin = getEventOrigin(event);
+	if (origin) {
 		// 菜单点击切换时使用 View Transitions 圆形扩散动画
-		setThemeWithAnimation(newMode, event.clientX, event.clientY);
+		setThemeWithAnimation(newMode, origin.x, origin.y);
 	} else {
 		// 程序化切换或无坐标来源时保持原来的直接切换逻辑
 		setTheme(newMode);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -71,52 +71,38 @@ html {
 
 @layer components {
     /* View Transitions API 主题切换动画 */
-    /* 为整个文档根元素设置视图过渡 */
+    /* 根视图快照保持正常混合，避免明暗主题叠加时出现异常反色 */
     ::view-transition-old(root),
     ::view-transition-new(root) {
-        animation-duration: 0.5s;
-        animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-        /* 使用混合模式使颜色过渡更平滑 */
         mix-blend-mode: normal;
     }
     
-    /* 视图过渡组 - 使用交叉淡化效果 */
+    /* 统一控制根视图过渡时长和缓动曲线 */
     ::view-transition-group(root) {
         animation-duration: 0.5s;
         animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     }
     
-    /* 淡出旧视图 - 使用更平滑的曲线 */
+    /* 旧视图保持静止，作为底层等待新主题圆形扩散覆盖 */
     ::view-transition-old(root) {
-        animation-name: theme-fade-out;
-        /* 确保背景色同步切换 */
-        z-index: 2;
+        animation: none;
+        z-index: 0;
     }
     
-    /* 淡入新视图 - 使用更平滑的曲线 */
+    /* 新视图从点击坐标开始圆形扩散，坐标由主题切换逻辑写入 CSS 变量 */
     ::view-transition-new(root) {
-        animation-name: theme-fade-in;
-        /* 确保新视图在上层 */
+        animation: theme-circle-expand 0.5s cubic-bezier(0.4, 0, 0.2, 1) both;
+        clip-path: circle(0% at var(--click-x, 50%) var(--click-y, 50%));
         z-index: 1;
     }
     
-    /* 定义淡出动画 - 使用更平滑的缓动函数 */
-    @keyframes theme-fade-out {
+    /* 圆形半径扩展到 150%，确保从任意点击位置都能覆盖完整视口 */
+    @keyframes theme-circle-expand {
         0% {
-            opacity: 1;
+            clip-path: circle(0% at var(--click-x, 50%) var(--click-y, 50%));
         }
         100% {
-            opacity: 0;
-        }
-    }
-    
-    /* 定义淡入动画 - 从下层淡入 */
-    @keyframes theme-fade-in {
-        0% {
-            opacity: 0;
-        }
-        100% {
-            opacity: 1;
+            clip-path: circle(150% at var(--click-x, 50%) var(--click-y, 50%));
         }
     }
     

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -92,17 +92,31 @@ html {
     /* 新视图从点击坐标开始圆形扩散，坐标由主题切换逻辑写入 CSS 变量 */
     ::view-transition-new(root) {
         animation: theme-circle-expand 0.5s cubic-bezier(0.4, 0, 0.2, 1) both;
-        clip-path: circle(0% at var(--click-x, 50%) var(--click-y, 50%));
+        clip-path: circle(0 at var(--click-x, 50%) var(--click-y, 50%));
         z-index: 1;
     }
     
-    /* 圆形半径扩展到 150%，确保从任意点击位置都能覆盖完整视口 */
+    /* 圆形半径扩展到 150vmax，确保极端视口比例和角落点击时也能覆盖完整屏幕 */
     @keyframes theme-circle-expand {
         0% {
-            clip-path: circle(0% at var(--click-x, 50%) var(--click-y, 50%));
+            clip-path: circle(0 at var(--click-x, 50%) var(--click-y, 50%));
         }
         100% {
-            clip-path: circle(150% at var(--click-x, 50%) var(--click-y, 50%));
+            clip-path: circle(150vmax at var(--click-x, 50%) var(--click-y, 50%));
+        }
+    }
+
+    /* 尊重减少动态效果偏好，避免播放完整圆形扩散动画 */
+    @media (prefers-reduced-motion: reduce) {
+        ::view-transition-group(root),
+        ::view-transition-old(root),
+        ::view-transition-new(root) {
+            animation-duration: 0.01ms;
+            animation-name: none;
+        }
+
+        ::view-transition-new(root) {
+            clip-path: none;
         }
     }
     
@@ -571,4 +585,3 @@ html {
 .pagination-info {
   @apply text-sm text-(--text-secondary) text-center mb-2;
 }
-

--- a/src/utils/setting-utils.ts
+++ b/src/utils/setting-utils.ts
@@ -185,18 +185,27 @@ export function setTheme(theme: LIGHT_DARK_MODE): void {
 // 使用 View Transitions API 执行带点击坐标的圆形扩散主题切换
 export function setThemeWithAnimation(
 	theme: LIGHT_DARK_MODE,
-	clickX: number,
-	clickY: number,
+	clickX?: number,
+	clickY?: number,
 ): void {
-	if (typeof document === "undefined") {
+	if (typeof document === "undefined" || typeof window === "undefined") {
 		// 非浏览器环境没有可动画的文档，直接走核心切换逻辑
 		setThemeCore(theme);
 		return;
 	}
 
-	// 将点击位置传给 CSS，作为 clip-path: circle() 的圆心
-	document.documentElement.style.setProperty("--click-x", `${clickX}px`);
-	document.documentElement.style.setProperty("--click-y", `${clickY}px`);
+	const hasValidOrigin =
+		typeof clickX === "number" &&
+		typeof clickY === "number" &&
+		Number.isFinite(clickX) &&
+		Number.isFinite(clickY) &&
+		(clickX > 0 || clickY > 0);
+	const originX = hasValidOrigin ? clickX : window.innerWidth / 2;
+	const originY = hasValidOrigin ? clickY : window.innerHeight / 2;
+
+	// 将有效触发位置传给 CSS，作为 clip-path: circle() 的圆心
+	document.documentElement.style.setProperty("--click-x", `${originX}px`);
+	document.documentElement.style.setProperty("--click-y", `${originY}px`);
 
 	// TypeScript 当前 DOM 类型可能缺少 startViewTransition，局部补齐即可
 	const viewTransitionDocument = document as Document & {

--- a/src/utils/setting-utils.ts
+++ b/src/utils/setting-utils.ts
@@ -152,7 +152,8 @@ let systemThemeListener:
 	| ((e: MediaQueryListEvent | MediaQueryList) => void)
 	| null = null;
 
-export function setTheme(theme: LIGHT_DARK_MODE): void {
+// 主题切换的核心逻辑，只负责应用主题、保存配置和维护系统主题监听
+function setThemeCore(theme: LIGHT_DARK_MODE): void {
 	// 检查是否在浏览器环境中
 	if (
 		typeof localStorage === "undefined" ||
@@ -174,6 +175,44 @@ export function setTheme(theme: LIGHT_DARK_MODE): void {
 		// 如果切换其他模式，移除系统主题监听
 		cleanupSystemThemeListener();
 	}
+}
+
+export function setTheme(theme: LIGHT_DARK_MODE): void {
+	// 默认入口保持无动画切换，供初始化、系统变化和程序化调用复用
+	setThemeCore(theme);
+}
+
+// 使用 View Transitions API 执行带点击坐标的圆形扩散主题切换
+export function setThemeWithAnimation(
+	theme: LIGHT_DARK_MODE,
+	clickX: number,
+	clickY: number,
+): void {
+	if (typeof document === "undefined") {
+		// 非浏览器环境没有可动画的文档，直接走核心切换逻辑
+		setThemeCore(theme);
+		return;
+	}
+
+	// 将点击位置传给 CSS，作为 clip-path: circle() 的圆心
+	document.documentElement.style.setProperty("--click-x", `${clickX}px`);
+	document.documentElement.style.setProperty("--click-y", `${clickY}px`);
+
+	// TypeScript 当前 DOM 类型可能缺少 startViewTransition，局部补齐即可
+	const viewTransitionDocument = document as Document & {
+		startViewTransition?: (callback: () => void) => void;
+	};
+
+	if (typeof viewTransitionDocument.startViewTransition === "function") {
+		// 浏览器会在回调前后截取旧/新视图，CSS 再控制新视图圆形扩散
+		viewTransitionDocument.startViewTransition(() => {
+			setThemeCore(theme);
+		});
+		return;
+	}
+
+	// 不支持 View Transitions 的浏览器直接切换，保证功能可用
+	setThemeCore(theme);
 }
 
 // 设置系统主题监听器


### PR DESCRIPTION
## 变更内容

- 为浅色 / 深色 / 跟随系统主题切换增加基于 View Transitions API 的圆形扩散动画。
- 在 `LightDarkSwitch.svelte` 中传递菜单点击坐标，让新主题从用户点击位置开始扩散。
- 将原来的根视图淡入淡出过渡替换为 `clip-path: circle()` 圆形展开动画。
- 保留不支持 `document.startViewTransition` 浏览器的直接切换兜底逻辑。

## 修改原因

原有主题切换使用全页面淡入淡出，虽然能避免闪切，但动画与用户点击位置没有关联。这次改动让新主题从点击的主题菜单项位置扩散出来，交互反馈更明确，同时不影响原有主题切换行为。

## 影响范围

- Chromium 系浏览器会使用 View Transitions API 播放圆形扩散动画。
- 不支持 View Transitions API 的浏览器仍然直接切换主题。
- 初始化、系统主题变化和其他程序化主题切换继续使用无动画的 `setTheme` 入口。

## 验证

- 本地执行 `astro check` 通过，结果为 0 errors / 0 warnings / 0 hints。

## Summary by Sourcery

引入基于点击起点的圆形 View Transitions 动画用于主题切换，同时保留对不动画和不支持相关功能的浏览器的兼容行为。

新功能：
- 新增 `setThemeWithAnimation` API，用于通过 View Transitions API 在交互点处生成圆形扩散动画来执行主题切换。
- 为根视图添加基于 `clip-path` 的圆形扩展动画，并根据点击坐标在切换亮色/暗色/系统主题时进行过渡。

增强优化：
- 将主题切换逻辑重构为核心函数 `setThemeCore`，由带动画和不带动画的入口共同复用。
- 在亮色/暗色切换控件中，从鼠标点击位置或键盘触发的菜单项位置推导动画起点坐标。
- 尊重用户的 `prefers-reduced-motion` 设置，通过弱化或禁用圆形过渡动画来减少动态效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce click-origin-based circular View Transitions animation for theme switching while preserving non-animated and non-supporting browser behavior.

New Features:
- Add setThemeWithAnimation API to perform theme changes with a circular expansion animation originating from the interaction point using the View Transitions API.
- Animate the root view with a clip-path-based circle expansion keyed by click coordinates for light/dark/system theme toggling.

Enhancements:
- Refactor theme switching logic into a core setThemeCore function reused by both animated and non-animated entry points.
- Derive animation origin coordinates from mouse clicks or keyboard-triggered menu item positions in the Light/Dark switch control.
- Respect prefers-reduced-motion user settings by minimizing or disabling the circular transition animation.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入基于点击起点的圆形 View Transitions 动画用于主题切换，同时保留对不动画和不支持相关功能的浏览器的兼容行为。

新功能：
- 新增 `setThemeWithAnimation` API，用于通过 View Transitions API 在交互点处生成圆形扩散动画来执行主题切换。
- 为根视图添加基于 `clip-path` 的圆形扩展动画，并根据点击坐标在切换亮色/暗色/系统主题时进行过渡。

增强优化：
- 将主题切换逻辑重构为核心函数 `setThemeCore`，由带动画和不带动画的入口共同复用。
- 在亮色/暗色切换控件中，从鼠标点击位置或键盘触发的菜单项位置推导动画起点坐标。
- 尊重用户的 `prefers-reduced-motion` 设置，通过弱化或禁用圆形过渡动画来减少动态效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce click-origin-based circular View Transitions animation for theme switching while preserving non-animated and non-supporting browser behavior.

New Features:
- Add setThemeWithAnimation API to perform theme changes with a circular expansion animation originating from the interaction point using the View Transitions API.
- Animate the root view with a clip-path-based circle expansion keyed by click coordinates for light/dark/system theme toggling.

Enhancements:
- Refactor theme switching logic into a core setThemeCore function reused by both animated and non-animated entry points.
- Derive animation origin coordinates from mouse clicks or keyboard-triggered menu item positions in the Light/Dark switch control.
- Respect prefers-reduced-motion user settings by minimizing or disabling the circular transition animation.

</details>

</details>