### PR TITLE
fix: Build error on Astro 7.0.4

### DIFF
--- a/src/components/layout/NavMenuPanel.astro
+++ b/src/components/layout/NavMenuPanel.astro
@@ -13,7 +13,7 @@ const processedLinks = Astro.props.links;
     {processedLinks.map((link) => (
         <div class="mobile-menu-item">
             {link.children && link.children.length > 0 ? (
-                <!-- 有子菜单的项目 -->
+                /* 有子菜单的项目 */
                 <div class="mobile-dropdown" data-mobile-dropdown>
                     <button
                         class="group flex justify-between items-center py-2 pl-3 pr-1 rounded-lg gap-8 w-full text-left
@@ -48,7 +48,7 @@ const processedLinks = Astro.props.links;
                     </div>
                 </div>
             ) : (
-                <!-- 普通链接项目 -->
+                /* 普通链接项目 */
                 <a href={link.external ? link.url : url(link.url)} class="group flex justify-between items-center py-2 pl-3 pr-1 rounded-lg gap-8
                     hover:bg-(--btn-plain-bg-hover) active:bg-(--btn-plain-bg-active) transition
                 "

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -325,7 +325,7 @@ const hasMultipleImages =
 }>
     <!-- 背景图片显示 -->
     {hasMultipleImages ? (
-    <!-- 轮播模式：渲染所有图片为 slide-item -->
+    /* 轮播模式：渲染所有图片为 slide-item */
     <div class:list={["relative h-full w-full bg-black", `effect-${bannerCarouselEffect}`]} id="banner-images-container"
          style={`z-index: 5; --carousel-interval: ${bannerCarouselInterval}ms`}
          data-carousel-enabled={bannerCarouselEnabledDefault}
@@ -365,7 +365,7 @@ const hasMultipleImages =
         ))}
     </div>
     ) : (
-    <!-- 单图模式 -->
+    /* 单图模式 */
     <div class="relative h-full w-full" id="banner-images-container">
         {backgroundImages.mobile.length > 0 && (
             <div class="banner-image-slot-mobile absolute inset-0 block lg:hidden">

--- a/src/pages/anime.astro
+++ b/src/pages/anime.astro
@@ -270,7 +270,7 @@ const isConfigured = !!(BILIBILI_UID || (TMDB_API_KEY && TMDB_LIST_ID));
         </div>
 
         {!isConfigured ? (
-          <!-- 未配置提示 -->
+          /* 未配置提示 */
           <div class="text-center py-16">
             <div class="inline-flex items-center justify-center w-16 h-16 bg-(--btn-regular-bg) rounded-full mb-6 border border-(--line-divider)">
               <Icon is:inline name="material-symbols:settings" class="text-[2rem] text-(--btn-content)" />
@@ -334,7 +334,7 @@ const isConfigured = !!(BILIBILI_UID || (TMDB_API_KEY && TMDB_LIST_ID));
               </div>
             </div>
 
-            <!-- 番剧网格（Svelte 交互组件） -->
+            {/* 番剧网格（Svelte 交互组件） */}
             <AnimeGrid
               client:load
               items={animeList}

--- a/src/pages/og/[...slug].ts
+++ b/src/pages/og/[...slug].ts
@@ -32,7 +32,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 		// 将 id 转换为 slug（移除扩展名）以匹配路由参数
 		const slug = removeFileExtension(post.id);
 		return {
-			params: { slug },
+			params: { slug: `${slug}.png` },
 			props: { post },
 		};
 	});


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Changes

<!-- Please describe the changes you made in this pull request. -->

This PR fix build error on Astro 7.0.4 (or 7.0.2~7.0.3 and run ``pnpm update``) by change some comment part.  
and fix ``NoMatchingStaticPathFound`` error on OpenGraph image generator script.

since after update to that versions I found error when build.

```
11:19:30 [ERROR] [vite] ✗ Build failed in 31.81s
[CompilerError] Unexpected token
  Location:
    [plugin astro:build] D:/symlink/happiness2script/vue/sakublog-astro/src/pages/anime.astro:273:11
  Stack trace:
    at handleCompileResultErrors (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/compile/compile.js:67:11)
    at async compileAstro (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/vite-plugin-astro/compile.js:7:27)
    at async plugin (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/bindingify-input-options-CzVhGygm.mjs:1513:16)
    at handleCompileResultErrors (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/compile/compile.js:67:11)
    at async compileAstro (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/vite-plugin-astro/compile.js:7:27)
    at async plugin (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/bindingify-input-options-CzVhGygm.mjs:1513:16)
    at handleCompileResultErrors (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/compile/compile.js:67:11)
    at async compileAstro (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/vite-plugin-astro/compile.js:7:27)
    at async plugin (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/bindingify-input-options-CzVhGygm.mjs:1513:16)
    at aggregateBindingErrorsIntoJsError (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/error-B68YLzl3.mjs:48:18)
    at #build (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/rolldown-build-DR0wzp0V.mjs:3256:34)
    at async Object.build (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/vite@8.1.0_@types+node@25.9_4d413dba81f1910c37d82a292f108150/node_modules/vite/dist/node/chunks/node.js:32997:19)
    at async Object.buildApp (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/vite@8.1.0_@types+node@25.9_4d413dba81f1910c37d82a292f108150/node_modules/vite/dist/node/chunks/node.js:32989:6)
    at async viteBuild (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/build/static-build.js:68:3)
[ELIFECYCLE] Command failed with exit code 1.
```

```
12:10:52 [ERROR] [vite] ✗ Build failed in 36.76s
[CompilerError] Unexpected token
  Location:
    [plugin astro:build] D:/symlink/happiness2script/vue/sakublog-astro/src/layouts/MainGridLayout.astro:328:5
  Stack trace:
    at handleCompileResultErrors (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/compile/compile.js:67:11)
    at async compileAstro (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/vite-plugin-astro/compile.js:7:27)
    at async plugin (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/bindingify-input-options-CzVhGygm.mjs:1513:16)
    at handleCompileResultErrors (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/compile/compile.js:67:11)
    at async compileAstro (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/vite-plugin-astro/compile.js:7:27)
    at async plugin (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/bindingify-input-options-CzVhGygm.mjs:1513:16)
    at aggregateBindingErrorsIntoJsError (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/error-B68YLzl3.mjs:48:18)
    at #build (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/rolldown-build-DR0wzp0V.mjs:3256:34)
    at async Object.build (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/vite@8.1.0_@types+node@25.9_4d413dba81f1910c37d82a292f108150/node_modules/vite/dist/node/chunks/node.js:32997:19)
    at async Object.buildApp (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/vite@8.1.0_@types+node@25.9_4d413dba81f1910c37d82a292f108150/node_modules/vite/dist/node/chunks/node.js:32989:6)
    at async viteBuild (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/build/static-build.js:68:3)
[ELIFECYCLE] Command failed with exit code 1.
```

```
12:14:14 [ERROR] [vite] ✗ Build failed in 8.11s
[CompilerError] Unexpected token
  Location:
    [plugin astro:build] D:/symlink/happiness2script/vue/sakublog-astro/src/components/layout/NavMenuPanel.astro:16:17
  Stack trace:
    at handleCompileResultErrors (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/compile/compile.js:67:11)
    at async compileAstro (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/vite-plugin-astro/compile.js:7:27)
    at async plugin (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/bindingify-input-options-CzVhGygm.mjs:1513:16)
    at aggregateBindingErrorsIntoJsError (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/error-B68YLzl3.mjs:48:18)
    at #build (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/rolldown@1.1.3/node_modules/rolldown/dist/shared/rolldown-build-DR0wzp0V.mjs:3256:34)
    at async Object.build (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/vite@8.1.0_@types+node@25.9_4d413dba81f1910c37d82a292f108150/node_modules/vite/dist/node/chunks/node.js:32997:19)
    at async Object.buildApp (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/vite@8.1.0_@types+node@25.9_4d413dba81f1910c37d82a292f108150/node_modules/vite/dist/node/chunks/node.js:32989:6)
    at async viteBuild (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/build/static-build.js:68:3)
[ELIFECYCLE] Command failed with exit code 1.
```

```
12:20:18   ├─ /og/2015-06-04-server-back-to-online.png/12:20:18 [ERROR] NoMatchingStaticPathFound: A `getStaticPaths()` route pattern was matched, but no matching static path was found for requested path `/og/[my-post].png/`.
    at getProps (file:///D:/symlink/happiness2script/vue/sakublog-astro/dist/.prerender/chunks/ssr-element_C-8ZWHVa.mjs:360:104)
    at async FetchState.getProps (file:///D:/symlink/happiness2script/vue/sakublog-astro/dist/.prerender/chunks/ssr-element_C-8ZWHVa.mjs:3930:16)
    at async AstroMiddleware.handle (file:///D:/symlink/happiness2script/vue/sakublog-astro/dist/.prerender/chunks/ssr-element_C-8ZWHVa.mjs:3015:3)
    at async AstroHandler.render (file:///D:/symlink/happiness2script/vue/sakublog-astro/dist/.prerender/prerender-entry.D7R0dQMI.mjs:1170:16)
    at async BuildApp.render (file:///D:/symlink/happiness2script/vue/sakublog-astro/dist/.prerender/prerender-entry.D7R0dQMI.mjs:1552:15)
    at async renderPath (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/build/generate.js:246:16)
    at async generatePathWithPrerenderer (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/build/generate.js:305:18)
    at async generatePages (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/build/generate.js:135:9)
    at async BasicMinimalPluginContext.handler (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/build/static-build.js:118:11)
    at async Object.buildApp (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/vite@8.1.0_@types+node@25.9_4d413dba81f1910c37d82a292f108150/node_modules/vite/dist/node/chunks/node.js:32991:5)
12:20:18 [ERROR] [build] Caught error rendering /og/2015-06-04-server-back-to-online.png/: NoMatchingStaticPathFound: A `getStaticPaths()` route pattern was matched, but no matching static path was found for requested path `/og/[my-post].png/`.
[NoMatchingStaticPathFound] A `getStaticPaths()` route pattern was matched, but no matching static path was found for requested path `/og/2015-06-04-server-back-to-online.png/`.
  Hint:
    Possible dynamic routes being matched: src/pages/og/[...slug].png.ts.
  Error reference:
    https://docs.astro.build/en/reference/errors/no-matching-static-path-found/
  Location:
    D:\symlink\happiness2script\vue\sakublog-astro\node_modules\.pnpm\astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d\node_modules\astro\dist\core\build\generate.js:246:16
  Stack trace:
    at getProps (file:///D:/symlink/happiness2script/vue/sakublog-astro/dist/.prerender/chunks/ssr-element_C-8ZWHVa.mjs:360:104)
    at async AstroMiddleware.handle (file:///D:/symlink/happiness2script/vue/sakublog-astro/dist/.prerender/chunks/ssr-element_C-8ZWHVa.mjs:3015:3)
    at async BuildApp.render (file:///D:/symlink/happiness2script/vue/sakublog-astro/dist/.prerender/prerender-entry.D7R0dQMI.mjs:1552:15)
    at async generatePathWithPrerenderer (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/build/generate.js:305:18)
    at async BasicMinimalPluginContext.handler (file:///D:/symlink/happiness2script/vue/sakublog-astro/node_modules/.pnpm/astro@7.0.4_@astrojs+markdo_2a0efd93d88d52c421d2229d96617e7d/node_modules/astro/dist/core/build/static-build.js:118:11)
[ELIFECYCLE] Command failed with exit code 1.
```

## How To Test

<!-- Please describe how you tested your changes. -->

1. Update Astro to version 7.0.4 (or 7.0.3 and run ``pnpm update``)
2. build site

it's should build successful without any error.  
tested on my own build

## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->

## Summary by Sourcery

通过调整 Astro 组件标记中的注释以及 OpenGraph 路由参数，修复 Astro 7.x 引入的构建和静态路径错误。

Bug 修复：
- 通过在多个模板中，将 JSX 风格表达式中的无效 HTML 注释语法替换为有效语法，解决 Astro 编译器在构建时出现的 `Unexpected token` 错误。
- 通过调整 `getStaticPaths`，让其为 OG 路由输出包含 `.png` 扩展名的 slug，修复用于生成 OpenGraph 图像时出现的 `NoMatchingStaticPathFound` 错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix build and static path errors introduced with Astro 7.x by adjusting Astro component markup comments and OpenGraph route parameters.

Bug Fixes:
- Resolve Astro compiler `Unexpected token` build failures by replacing invalid HTML comment syntax within JSX-style expressions in multiple templates.
- Fix `NoMatchingStaticPathFound` errors for OpenGraph image generation by adjusting `getStaticPaths` to emit slugs that include the `.png` extension for the OG route.

</details>