### PR TITLE
feat: 重新设计文章列表卡片部分布局

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+Firefly is an Astro 7 site with Svelte islands and TypeScript configuration. Main source code lives in `src/`: routes in `src/pages`, layouts in `src/layouts`, reusable UI in `src/components`, styles in `src/styles`, content in `src/content`, helpers in `src/utils`, and Markdown/HTML plugins in `src/plugins`. Site configuration is split across `src/config` with matching type definitions in `src/types`; prefer imports from `@/config` when available. Static files served directly belong in `public`, source-managed images in `src/assets`, docs in `docs` and `Firefly-Docs`, and automation in `scripts`.
+
+## Build, Test, and Development Commands
+
+Use `pnpm`; the `preinstall` script enforces it.
+
+- `pnpm dev` or `pnpm start`: run the local Astro dev server.
+- `pnpm check`: run Astro diagnostics.
+- `pnpm type-check`: run TypeScript with `--noEmit`.
+- `pnpm format`: format `src` with Biome.
+- `pnpm lint`: run Biome checks and safe fixes on `src`.
+- `pnpm build`: generate icons, LQIPs, the Astro build, font subsets, and Pagefind search output in `dist`.
+- `pnpm preview`: preview the production build locally.
+- `pnpm new-post`: scaffold a new content post.
+
+## Coding Style & Naming Conventions
+
+Biome is the formatter and linter. It uses tabs for indentation and double quotes for JavaScript/TypeScript strings. Keep Astro and Svelte components in `PascalCase` (`PostCard.astro`, `ArchivePanel.svelte`), config modules in `camelCase` ending with `Config.ts`, and utilities in descriptive kebab case such as `date-utils.ts`. Keep `src/types` aligned with `src/config`. Avoid unrelated formatting churn.
+
+## Testing Guidelines
+
+There is no dedicated unit-test framework configured. Before submitting changes, run `pnpm check`, `pnpm type-check`, and `pnpm build` for rendering, content, or generated asset work. For visual or interactive changes, verify with `pnpm dev` or `pnpm preview` and include screenshots in the PR. Name future tests near the feature they cover, using the local file name as the stem.
+
+## Commit & Pull Request Guidelines
+
+Use Conventional Commits, matching the current history: `feat: ...`, `fix: ...`, and `chore: ...`. Keep commits and PRs focused on one concern. PRs should include a concise summary, linked issues when relevant, validation commands run, and screenshots for UI changes. Discuss major features or design changes in an issue or discussion before implementation.
+
+## Security & Configuration Tips
+
+Do not commit secrets, tokens, or service keys in config files. Keep deployment-specific settings in the target platform environment, and review generated files such as `dist`, `src/constants/lqips.json`, and `src/constants/icons.ts` before committing them.

--- a/src/components/layout/PostCard.astro
+++ b/src/components/layout/PostCard.astro
@@ -4,6 +4,7 @@ import { render } from "astro:content";
 import { Icon } from "astro-icon/components";
 import CoverImage from "@/components/common/CoverImage.astro";
 import PostMetadata from "@/components/layout/PostMeta.astro";
+import PostStats from "@/components/layout/PostStats.astro";
 import { siteConfig } from "@/config";
 import { getApiUrlList, processCoverImageSync } from "@/utils/image-utils";
 import { getFileDirFromPath } from "@/utils/url-utils";
@@ -138,16 +139,11 @@ const minutes = remarkPluginFrontmatter.minutes;
     </div>
 
     <!-- stats -->
-    <PostMetadata
+    <PostStats
       published={published}
       words={words}
       minutes={minutes}
-      showCategory={false}
-      showTags={false}
-      hideUpdateDate={true}
-      showWords={true}
-      showReadingTime={false}
-      variant="stats"
+      showIcons={siteConfig.postListLayout.showStatsIcons}
       className="stats mt-auto pt-3 text-black/30 dark:text-white/30 gap-x-2"
     />
   </div>

--- a/src/components/layout/PostCard.astro
+++ b/src/components/layout/PostCard.astro
@@ -5,10 +5,8 @@ import { Icon } from "astro-icon/components";
 import CoverImage from "@/components/common/CoverImage.astro";
 import PostMetadata from "@/components/layout/PostMeta.astro";
 import { siteConfig } from "@/config";
-import I18nKey from "@/i18n/i18nKey";
-import { i18n } from "@/i18n/translation";
 import { getApiUrlList, processCoverImageSync } from "@/utils/image-utils";
-import { getFileDirFromPath, getTagUrl } from "@/utils/url-utils";
+import { getFileDirFromPath } from "@/utils/url-utils";
 
 interface Props {
 	class?: string;
@@ -54,6 +52,10 @@ const hasCover =
 const coverWidth = "30%";
 
 const showTags = siteConfig.postListLayout.showTags;
+const tagCount = Math.max(
+	0,
+	Math.trunc(siteConfig.postListLayout.tagCount ?? 1),
+);
 const descriptionLines = Math.max(
 	0,
 	Math.trunc(siteConfig.postListLayout.descriptionLines ?? 2),
@@ -63,6 +65,8 @@ const shouldClampDescription = descriptionLines > 0;
 
 const { remarkPluginFrontmatter } = await render(entry);
 const descriptionText = description || remarkPluginFrontmatter.excerpt || "";
+const words = remarkPluginFrontmatter.words;
+const minutes = remarkPluginFrontmatter.minutes;
 ---
 
 <div
@@ -111,11 +115,15 @@ const descriptionText = description || remarkPluginFrontmatter.excerpt || "";
     <PostMetadata
       published={published}
       tags={tags}
-      showTags={false}
+      showPublished={false}
+      showTags={showTags && tagCount > 0}
+      maxTags={tagCount}
+      showNoTags={false}
+      hideUpdateDate={true}
       category={category || undefined}
       pinned={pinned}
       password={password}
-      className="mb-4 post-meta"
+      className="mb-4 post-meta card-header-meta"
     />
 
     <!-- description -->
@@ -129,30 +137,19 @@ const descriptionText = description || remarkPluginFrontmatter.excerpt || "";
       {descriptionText}
     </div>
 
-    <!-- tags -->
-    {
-      showTags && (
-        <div class="text-sm text-black/30 dark:text-white/30 flex flex-wrap gap-2 transition stats pt-3">
-          {tags &&
-            tags.length > 0 &&
-            tags.map((tag, _i) => (
-              <a
-                href={getTagUrl(tag)}
-                aria-label={`View all posts with the ${tag.trim()} tag`}
-                class="btn-regular h-6 text-xs px-2 py-1 rounded-md
-                         transition-all duration-200 hover:scale-105 active:scale-95"
-              >
-                #{tag.trim()}
-              </a>
-            ))}
-          {!(tags && tags.length > 0) && (
-            <span class="text-(--content-meta) text-xs">
-              #{i18n(I18nKey.noTags)}
-            </span>
-          )}
-        </div>
-      )
-    }
+    <!-- stats -->
+    <PostMetadata
+      published={published}
+      words={words}
+      minutes={minutes}
+      showCategory={false}
+      showTags={false}
+      hideUpdateDate={true}
+      showWords={true}
+      showReadingTime={false}
+      variant="stats"
+      className="stats mt-auto pt-3 text-black/30 dark:text-white/30 gap-x-2"
+    />
   </div>
   {
     hasCover && (

--- a/src/components/layout/PostMeta.astro
+++ b/src/components/layout/PostMeta.astro
@@ -218,7 +218,7 @@ const visibleTags =
   {
     !isHome &&
       commentConfig.type === "artalk" &&
-      commentConfig.waline?.visitorCount &&
+      commentConfig.artalk?.visitorCount &&
       id && (
         <div class="flex items-center">
           <div class="meta-icon">

--- a/src/components/layout/PostMeta.astro
+++ b/src/components/layout/PostMeta.astro
@@ -16,16 +16,11 @@ export interface Props {
 	isHome?: boolean;
 	className?: string;
 	id?: string;
-	words?: number;
-	minutes?: number;
 	showPublished?: boolean;
 	showCategory?: boolean;
 	showTags?: boolean;
 	maxTags?: number;
 	showNoTags?: boolean;
-	showWords?: boolean;
-	showReadingTime?: boolean;
-	variant?: "default" | "stats";
 	customPath?: string;
 	pinned?: boolean;
 	password?: boolean;
@@ -41,16 +36,11 @@ const {
 	isHome,
 	className = "",
 	id,
-	words,
-	minutes,
 	showPublished = true,
 	showCategory = true,
 	showTags = true,
 	maxTags,
 	showNoTags = true,
-	showWords = false,
-	showReadingTime = false,
-	variant = "default",
 	customPath,
 	pinned,
 } = Astro.props;
@@ -58,28 +48,11 @@ const {
 const path = customPath || (id ? `/posts/${id}` : "");
 const visibleTags =
 	typeof maxTags === "number" ? tags?.slice(0, maxTags) : tags;
-const hasPublishedMeta = showPublished;
-const hasWordsMeta = showWords && typeof words === "number";
-const hasMinutesMeta = showReadingTime && typeof minutes === "number";
-const showStatsDivider = variant === "stats";
-const rootClass =
-	variant === "stats"
-		? "flex flex-wrap items-center gap-2 gap-x-2 gap-y-1.5"
-		: "post-meta-root flex flex-wrap text-neutral-500 dark:text-neutral-400 items-center gap-4 gap-x-4 gap-y-2";
-const iconWrapperClass =
-	variant === "stats"
-		? "transition h-5 w-5 rounded-md bg-black/5 dark:bg-white/10 text-black/50 dark:text-white/50 flex items-center justify-center mr-1.5"
-		: "meta-icon";
-const iconClass = variant === "stats" ? "text-sm" : "text-xl";
-const textClass =
-	variant === "stats" ? "text-xs font-medium" : "text-50 text-sm font-medium";
-const statsDividerClass =
-	"text-xs font-medium text-black/20 dark:text-white/20";
 ---
 
 <div
   class:list={[
-    rootClass,
+    "post-meta-root flex flex-wrap text-neutral-500 dark:text-neutral-400 items-center gap-4 gap-x-4 gap-y-2",
     className,
   ]}
 >
@@ -95,57 +68,15 @@ const statsDividerClass =
   {
     showPublished && (
       <div class="flex items-center">
-        <div class={iconWrapperClass}>
+        <div class="meta-icon">
           <Icon
             is:inline
             name="material-symbols:calendar-today-outline-rounded"
-            class={iconClass}
+            class="text-xl"
           />
         </div>
-        <span class={textClass}>
+        <span class="text-50 text-sm font-medium">
           {formatDateToYYYYMMDD(published)}
-        </span>
-      </div>
-    )
-  }
-
-  {
-    showStatsDivider && hasPublishedMeta && hasWordsMeta && (
-      <span class={statsDividerClass}>|</span>
-    )
-  }
-
-  {
-    hasWordsMeta && (
-      <div class="flex items-center">
-        <div class={iconWrapperClass}>
-          <Icon is:inline name="material-symbols:notes-rounded" class={iconClass} />
-        </div>
-        <span class={textClass}>
-          {words} {i18n(words === 1 ? I18nKey.wordCount : I18nKey.wordsCount)}
-        </span>
-      </div>
-    )
-  }
-
-  {
-    showStatsDivider && hasMinutesMeta && (hasPublishedMeta || hasWordsMeta) && (
-      <span class={statsDividerClass}>|</span>
-    )
-  }
-
-  {
-    hasMinutesMeta && (
-      <div class="flex items-center">
-        <div class={iconWrapperClass}>
-          <Icon
-            is:inline
-            name="material-symbols:schedule-outline-rounded"
-            class={iconClass}
-          />
-        </div>
-        <span class={textClass}>
-          {minutes} {i18n(minutes === 1 ? I18nKey.minuteCount : I18nKey.minutesCount)}
         </span>
       </div>
     )
@@ -157,14 +88,14 @@ const statsDividerClass =
       updated &&
       updated.getTime() !== published.getTime() && (
         <div class="flex items-center">
-          <div class={iconWrapperClass}>
+          <div class="meta-icon">
             <Icon
               is:inline
               name="material-symbols:edit-calendar-outline-rounded"
-              class={iconClass}
+              class="text-xl"
             />
           </div>
-          <span class={textClass}>
+          <span class="text-50 text-sm font-medium">
             {formatDateToYYYYMMDD(updated)}
           </span>
         </div>
@@ -174,8 +105,8 @@ const statsDividerClass =
   {
     showCategory && (
       <div class="flex items-center">
-        <div class={iconWrapperClass}>
-          <Icon is:inline name="material-symbols:book-2-outline-rounded" class={iconClass} />
+        <div class="meta-icon">
+          <Icon is:inline name="material-symbols:book-2-outline-rounded" class="text-xl" />
         </div>
         <div class="flex flex-row flex-nowrap items-center">
           <a
@@ -199,8 +130,8 @@ const statsDividerClass =
           { flex: !hideTagsForMobile, "hidden md:flex": hideTagsForMobile },
         ]}
       >
-        <div class={iconWrapperClass}>
-          <Icon is:inline name="material-symbols:tag-rounded" class={iconClass} />
+        <div class="meta-icon">
+          <Icon is:inline name="material-symbols:tag-rounded" class="text-xl" />
         </div>
         <div class="flex flex-row flex-nowrap items-center">
           {visibleTags &&
@@ -241,17 +172,17 @@ const statsDividerClass =
       commentConfig.twikoo?.visitorCount &&
       id && (
         <div class="flex items-center">
-          <div class={iconWrapperClass}>
+          <div class="meta-icon">
             <Icon
               is:inline
               name="material-symbols:visibility-outline-rounded"
-              class={iconClass}
+              class="text-xl"
             />
           </div>
-          <span class:list={[textClass, "mr-1"]}>
+          <span class="text-50 text-sm font-medium mr-1">
             {i18n(I18nKey.pageViews)}
           </span>
-          <span class={textClass} id="twikoo_visitors">
+          <span class="text-50 text-sm font-medium" id="twikoo_visitors">
             {i18n(I18nKey.pageViewsLoading)}
           </span>
         </div>
@@ -264,18 +195,18 @@ const statsDividerClass =
       commentConfig.waline?.visitorCount &&
       id && (
         <div class="flex items-center">
-          <div class={iconWrapperClass}>
+          <div class="meta-icon">
             <Icon
               is:inline
               name="material-symbols:visibility-outline-rounded"
-              class={iconClass}
+              class="text-xl"
             />
           </div>
-          <span class:list={[textClass, "mr-1"]}>
+          <span class="text-50 text-sm font-medium mr-1">
             {i18n(I18nKey.pageViews)}
           </span>
           <span
-            class:list={[textClass, "waline-pageview-count"]}
+            class="text-50 text-sm font-medium waline-pageview-count"
             data-path={path}
           >
             {i18n(I18nKey.pageViewsLoading)}
@@ -290,18 +221,18 @@ const statsDividerClass =
       commentConfig.waline?.visitorCount &&
       id && (
         <div class="flex items-center">
-          <div class={iconWrapperClass}>
+          <div class="meta-icon">
             <Icon
               is:inline
               name="material-symbols:visibility-outline-rounded"
-              class={iconClass}
+              class="text-xl"
             />
           </div>
-          <span class:list={[textClass, "mr-1"]}>
+          <span class="text-50 text-sm font-medium mr-1">
             {i18n(I18nKey.pageViews)}
           </span>
           <span
-            class:list={[textClass, "artalk-pv-count"]}
+            class="text-50 text-sm font-medium artalk-pv-count"
             data-path={path}
           >
             {i18n(I18nKey.pageViewsLoading)}

--- a/src/components/layout/PostMeta.astro
+++ b/src/components/layout/PostMeta.astro
@@ -18,7 +18,14 @@ export interface Props {
 	id?: string;
 	words?: number;
 	minutes?: number;
+	showPublished?: boolean;
+	showCategory?: boolean;
 	showTags?: boolean;
+	maxTags?: number;
+	showNoTags?: boolean;
+	showWords?: boolean;
+	showReadingTime?: boolean;
+	variant?: "default" | "stats";
 	customPath?: string;
 	pinned?: boolean;
 	password?: boolean;
@@ -34,21 +41,48 @@ const {
 	isHome,
 	className = "",
 	id,
+	words,
+	minutes,
+	showPublished = true,
+	showCategory = true,
 	showTags = true,
+	maxTags,
+	showNoTags = true,
+	showWords = false,
+	showReadingTime = false,
+	variant = "default",
 	customPath,
 	pinned,
 } = Astro.props;
 
 const path = customPath || (id ? `/posts/${id}` : "");
+const visibleTags =
+	typeof maxTags === "number" ? tags?.slice(0, maxTags) : tags;
+const hasPublishedMeta = showPublished;
+const hasWordsMeta = showWords && typeof words === "number";
+const hasMinutesMeta = showReadingTime && typeof minutes === "number";
+const showStatsDivider = variant === "stats";
+const rootClass =
+	variant === "stats"
+		? "flex flex-wrap items-center gap-2 gap-x-2 gap-y-1.5"
+		: "post-meta-root flex flex-wrap text-neutral-500 dark:text-neutral-400 items-center gap-4 gap-x-4 gap-y-2";
+const iconWrapperClass =
+	variant === "stats"
+		? "transition h-5 w-5 rounded-md bg-black/5 dark:bg-white/10 text-black/50 dark:text-white/50 flex items-center justify-center mr-1.5"
+		: "meta-icon";
+const iconClass = variant === "stats" ? "text-sm" : "text-xl";
+const textClass =
+	variant === "stats" ? "text-xs font-medium" : "text-50 text-sm font-medium";
+const statsDividerClass =
+	"text-xs font-medium text-black/20 dark:text-white/20";
 ---
 
 <div
   class:list={[
-    "post-meta-root flex flex-wrap text-neutral-500 dark:text-neutral-400 items-center gap-4 gap-x-4 gap-y-2",
+    rootClass,
     className,
   ]}
 >
-  <!-- pinned -->
   {
     pinned && (
       <div class="pinned-btn flex items-center gap-1 bg-(--btn-regular-bg) text-(--btn-content) rounded-md px-2 py-1.5 font-bold">
@@ -58,129 +92,221 @@ const path = customPath || (id ? `/posts/${id}` : "");
     )
   }
 
-  <!-- publish date -->
-  <div class="flex items-center">
-    <div class="meta-icon">
-      <Icon is:inline
-        name="material-symbols:calendar-today-outline-rounded"
-        class="text-xl"
-      />
-    </div>
-    <span class="text-50 text-sm font-medium"
-      >{formatDateToYYYYMMDD(published)}</span
-    >
-  </div>
-
-  <!-- update date -->
   {
-    !hideUpdateDate && updated && updated.getTime() !== published.getTime() && (
+    showPublished && (
       <div class="flex items-center">
-        <div class="meta-icon">
-          <Icon is:inline
-            name="material-symbols:edit-calendar-outline-rounded"
-            class="text-xl"
+        <div class={iconWrapperClass}>
+          <Icon
+            is:inline
+            name="material-symbols:calendar-today-outline-rounded"
+            class={iconClass}
           />
         </div>
-        <span class="text-50 text-sm font-medium">
-          {formatDateToYYYYMMDD(updated)}
+        <span class={textClass}>
+          {formatDateToYYYYMMDD(published)}
         </span>
       </div>
     )
   }
 
-  <!-- categories -->
-  <div class="flex items-center">
-    <div class="meta-icon">
-      <Icon is:inline name="material-symbols:book-2-outline-rounded" class="text-xl" />
-    </div>
-    <div class="flex flex-row flex-nowrap items-center">
-      <a
-        href={getCategoryUrl(category || "")}
-        aria-label={`View all posts in the ${category} category`}
-        class="link-lg transition text-50 text-sm font-medium
-                            hover:text-(--primary) dark:hover:text-(--primary) whitespace-nowrap"
+  {
+    showStatsDivider && hasPublishedMeta && hasWordsMeta && (
+      <span class={statsDividerClass}>|</span>
+    )
+  }
+
+  {
+    hasWordsMeta && (
+      <div class="flex items-center">
+        <div class={iconWrapperClass}>
+          <Icon is:inline name="material-symbols:notes-rounded" class={iconClass} />
+        </div>
+        <span class={textClass}>
+          {words} {i18n(words === 1 ? I18nKey.wordCount : I18nKey.wordsCount)}
+        </span>
+      </div>
+    )
+  }
+
+  {
+    showStatsDivider && hasMinutesMeta && (hasPublishedMeta || hasWordsMeta) && (
+      <span class={statsDividerClass}>|</span>
+    )
+  }
+
+  {
+    hasMinutesMeta && (
+      <div class="flex items-center">
+        <div class={iconWrapperClass}>
+          <Icon
+            is:inline
+            name="material-symbols:schedule-outline-rounded"
+            class={iconClass}
+          />
+        </div>
+        <span class={textClass}>
+          {minutes} {i18n(minutes === 1 ? I18nKey.minuteCount : I18nKey.minutesCount)}
+        </span>
+      </div>
+    )
+  }
+
+  {
+    showPublished &&
+      !hideUpdateDate &&
+      updated &&
+      updated.getTime() !== published.getTime() && (
+        <div class="flex items-center">
+          <div class={iconWrapperClass}>
+            <Icon
+              is:inline
+              name="material-symbols:edit-calendar-outline-rounded"
+              class={iconClass}
+            />
+          </div>
+          <span class={textClass}>
+            {formatDateToYYYYMMDD(updated)}
+          </span>
+        </div>
+      )
+  }
+
+  {
+    showCategory && (
+      <div class="flex items-center">
+        <div class={iconWrapperClass}>
+          <Icon is:inline name="material-symbols:book-2-outline-rounded" class={iconClass} />
+        </div>
+        <div class="flex flex-row flex-nowrap items-center">
+          <a
+            href={getCategoryUrl(category || "")}
+            aria-label={`View all posts in the ${category} category`}
+            class="link-lg transition text-50 text-sm font-medium
+              hover:text-(--primary) dark:hover:text-(--primary) whitespace-nowrap"
+          >
+            {category || i18n(I18nKey.uncategorized)}
+          </a>
+        </div>
+      </div>
+    )
+  }
+
+  {
+    showTags && (
+      <div
+        class:list={[
+          "items-center",
+          { flex: !hideTagsForMobile, "hidden md:flex": hideTagsForMobile },
+        ]}
       >
-        {category || i18n(I18nKey.uncategorized)}
-      </a>
-    </div>
-  </div>
+        <div class={iconWrapperClass}>
+          <Icon is:inline name="material-symbols:tag-rounded" class={iconClass} />
+        </div>
+        <div class="flex flex-row flex-nowrap items-center">
+          {visibleTags &&
+            visibleTags.length > 0 &&
+            visibleTags.map((tag, i) => (
+              <>
+                <div
+                  class:list={[
+                    { hidden: i === 0 },
+                    "mx-1.5 text-(--meta-divider) text-sm",
+                  ]}
+                >
+                  /
+                </div>
+                <a
+                  href={getTagUrl(tag)}
+                  aria-label={`View all posts with the ${tag.trim()} tag`}
+                  class="link-lg transition text-50 text-sm font-medium
+                    hover:text-(--primary) dark:hover:text-(--primary) whitespace-nowrap"
+                >
+                  {tag.trim()}
+                </a>
+              </>
+            ))}
+          {showNoTags && !(visibleTags && visibleTags.length > 0) && (
+            <div class="transition text-50 text-sm font-medium">
+              {i18n(I18nKey.noTags)}
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
 
-   <!-- tags -->
-   {
-     showTags && (
-       <div class:list={["items-center", {"flex": !hideTagsForMobile, "hidden md:flex": hideTagsForMobile}]}>
-         <div class="meta-icon">
-           <Icon is:inline name="material-symbols:tag-rounded" class="text-xl" />
-         </div>
-         <div class="flex flex-row flex-nowrap items-center">
-           {(tags && tags.length > 0) && tags.map((tag, i) => (
-             <div class:list={[{"hidden": i == 0}, "mx-1.5 text-(--meta-divider) text-sm"]}>/</div>
-             <a href={getTagUrl(tag)} aria-label={`View all posts with the ${tag.trim()} tag`}
-                class="link-lg transition text-50 text-sm font-medium
-                             hover:text-(--primary) dark:hover:text-(--primary) whitespace-nowrap">
-               {tag.trim()}
-             </a>
-           ))}
-           {!(tags && tags.length > 0) && <div class="transition text-50 text-sm font-medium">{i18n(I18nKey.noTags)}</div>}
-         </div>
-       </div>
-     )
-   }
-
-  <!-- Twikoo访问量统计（首页不显示，且文章访问量统计启用时显示） -->
   {
     !isHome &&
-      commentConfig.type === 'twikoo' &&
+      commentConfig.type === "twikoo" &&
       commentConfig.twikoo?.visitorCount &&
       id && (
         <div class="flex items-center">
-          <div class="meta-icon">
-            <Icon is:inline
+          <div class={iconWrapperClass}>
+            <Icon
+              is:inline
               name="material-symbols:visibility-outline-rounded"
-              class="text-xl"
+              class={iconClass}
             />
           </div>
-          <span class="text-50 text-sm font-medium mr-1">
+          <span class:list={[textClass, "mr-1"]}>
             {i18n(I18nKey.pageViews)}
           </span>
-          <span class="text-50 text-sm font-medium" id="twikoo_visitors">
+          <span class={textClass} id="twikoo_visitors">
             {i18n(I18nKey.pageViewsLoading)}
           </span>
         </div>
       )
   }
-  <!-- Waline访问量统计（首页不显示、仅type为waline时显示） -->
+
   {
     !isHome &&
-      commentConfig.type === 'waline' &&
+      commentConfig.type === "waline" &&
       commentConfig.waline?.visitorCount &&
       id && (
         <div class="flex items-center">
-          <div class="meta-icon">
-            <Icon is:inline name="material-symbols:visibility-outline-rounded" class="text-xl" />
+          <div class={iconWrapperClass}>
+            <Icon
+              is:inline
+              name="material-symbols:visibility-outline-rounded"
+              class={iconClass}
+            />
           </div>
-          <span class="text-50 text-sm font-medium mr-1">
+          <span class:list={[textClass, "mr-1"]}>
             {i18n(I18nKey.pageViews)}
           </span>
-          <span class="text-50 text-sm font-medium waline-pageview-count" data-path={path}>{i18n(I18nKey.pageViewsLoading)}</span>
+          <span
+            class:list={[textClass, "waline-pageview-count"]}
+            data-path={path}
+          >
+            {i18n(I18nKey.pageViewsLoading)}
+          </span>
         </div>
       )
   }
-    <!-- artalk访问量统计（首页不显示、仅type为artalk时显示） -->
-    {
-        !isHome &&
-        commentConfig.type === 'artalk' &&
-        commentConfig.waline?.visitorCount &&
-        id && (
-                    <div class="flex items-center">
-                        <div class="meta-icon">
-                            <Icon is:inline name="material-symbols:visibility-outline-rounded" class="text-xl" />
-                        </div>
-                        <span class="text-50 text-sm font-medium mr-1">
-                            {i18n(I18nKey.pageViews)}
-                        </span>
-                        <span class="text-50 text-sm font-medium artalk-pv-count" data-path={path}>{i18n(I18nKey.pageViewsLoading)}</span>
-                    </div>
-        )
-    }
+
+  {
+    !isHome &&
+      commentConfig.type === "artalk" &&
+      commentConfig.waline?.visitorCount &&
+      id && (
+        <div class="flex items-center">
+          <div class={iconWrapperClass}>
+            <Icon
+              is:inline
+              name="material-symbols:visibility-outline-rounded"
+              class={iconClass}
+            />
+          </div>
+          <span class:list={[textClass, "mr-1"]}>
+            {i18n(I18nKey.pageViews)}
+          </span>
+          <span
+            class:list={[textClass, "artalk-pv-count"]}
+            data-path={path}
+          >
+            {i18n(I18nKey.pageViewsLoading)}
+          </span>
+        </div>
+      )
+  }
 </div>

--- a/src/components/layout/PostPage.astro
+++ b/src/components/layout/PostPage.astro
@@ -337,6 +337,12 @@ const initialLayoutClass =
       margin-bottom: 0.25rem !important;
       width: 139% !important;
     }
+    .list-mode .post-meta.card-header-meta {
+      transform: scale(0.9) !important;
+      width: 111% !important;
+      margin-bottom: 0.5rem !important;
+      gap: 0.5rem !important;
+    }
     .list-mode :global(.post-meta) {
       margin-bottom: 0.25rem !important;
       gap: 0.25rem !important;
@@ -423,8 +429,36 @@ const initialLayoutClass =
     line-height: 1rem !important;
   }
 
+  #post-list-container.grid-mode :global(.card-header-meta .text-sm) {
+    font-size: 0.875rem !important;
+    line-height: 1.25rem !important;
+  }
+
+  #post-list-container.grid-mode :global(.card-header-meta .meta-icon) {
+    width: 2rem !important;
+    height: 2rem !important;
+    margin-right: 0.5rem !important;
+  }
+
+  #post-list-container.grid-mode :global(.card-header-meta .text-xl) {
+    font-size: 1.25rem !important;
+    line-height: 1.75rem !important;
+  }
+
   #post-list-container.grid-mode :global(.post-meta .pinned-btn) {
-    padding: 0.25rem 0.375rem !important;
+    height: 2rem !important;
+    padding: 0 0.5rem !important;
+    gap: 0.25rem !important;
+  }
+
+  #post-list-container.grid-mode :global(.post-meta .pinned-btn .text-xl) {
+    font-size: 1.25rem !important;
+    line-height: 1.75rem !important;
+  }
+
+  #post-list-container.grid-mode :global(.post-meta .pinned-btn .text-sm) {
+    font-size: 0.875rem !important;
+    line-height: 1.25rem !important;
   }
 
 </style>

--- a/src/components/layout/PostStats.astro
+++ b/src/components/layout/PostStats.astro
@@ -1,0 +1,82 @@
+---
+import { Icon } from "astro-icon/components";
+import I18nKey from "@/i18n/i18nKey";
+import { i18n } from "@/i18n/translation";
+import { formatDateToYYYYMMDD } from "@/utils/date-utils";
+
+export interface Props {
+	published: Date;
+	words?: number;
+	minutes?: number;
+	showPublished?: boolean;
+	showWords?: boolean;
+	showReadingTime?: boolean;
+	showIcons?: boolean;
+	className?: string;
+}
+
+const {
+	published,
+	words,
+	minutes,
+	showPublished = true,
+	showWords = true,
+	showReadingTime = true,
+	showIcons = false,
+	className = "",
+} = Astro.props;
+
+const hasPublished = showPublished;
+const hasWords = showWords && typeof words === "number";
+const hasMinutes = showReadingTime && typeof minutes === "number";
+const textClass = "text-xs font-medium";
+const dividerClass = "text-xs font-medium text-black/20 dark:text-white/20";
+const iconWrapperClass =
+	"transition h-5 w-5 rounded-md bg-black/5 dark:bg-white/10 text-black/50 dark:text-white/50 flex items-center justify-center mr-1.5";
+const iconClass = "text-sm";
+---
+
+<div class:list={["flex flex-wrap items-center gap-2", className]}>
+  {hasPublished && (
+    <div class="flex items-center">
+      {showIcons && (
+        <div class={iconWrapperClass}>
+          <Icon is:inline name="material-symbols:calendar-today-outline-rounded" class={iconClass} />
+        </div>
+      )}
+      <span class={textClass}>
+        {!showIcons && `${i18n(I18nKey.publishedAt)} `}{formatDateToYYYYMMDD(published)}
+      </span>
+    </div>
+  )}
+
+  {hasPublished && hasWords && <span class={dividerClass}>|</span>}
+
+  {hasWords && (
+    <div class="flex items-center">
+      {showIcons && (
+        <div class={iconWrapperClass}>
+          <Icon is:inline name="material-symbols:notes-rounded" class={iconClass} />
+        </div>
+      )}
+      <span class={textClass}>
+        {words} {i18n(words === 1 ? I18nKey.wordCount : I18nKey.wordsCount)}
+      </span>
+    </div>
+  )}
+
+  {(hasPublished || hasWords) && hasMinutes && <span class={dividerClass}>|</span>}
+
+  {hasMinutes && (
+    <div class="flex items-center">
+      {showIcons && (
+        <div class={iconWrapperClass}>
+          <Icon is:inline name="material-symbols:schedule-outline-rounded" class={iconClass} />
+        </div>
+      )}
+      <span class={textClass}>
+        {minutes} {i18n(minutes === 1 ? I18nKey.minuteCount : I18nKey.minutesCount)}
+      </span>
+    </div>
+  )}
+</div>

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -126,6 +126,8 @@ export const siteConfig: SiteConfig = {
 		mobileDefaultMode: "list",
 		// 是否在文章列表中显示标签
 		showTags: true,
+		// 文章列表中最多显示的标签数量
+		tagCount: 1,
 		// 文章简介显示行数，设为 0 则不截断
 		descriptionLines: 2,
 		// 是否允许用户切换布局

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -123,7 +123,7 @@ export const siteConfig: SiteConfig = {
 		// 默认布局模式："list" 列表模式（单列布局），"grid" 网格模式（多列布局）
 		defaultMode: "list",
 		// 移动端默认布局模式，不设置则跟随 defaultMode
-		mobileDefaultMode: "list",
+		mobileDefaultMode: "grid",
 		// 是否在文章列表中显示标签
 		showTags: true,
 		// 文章列表中最多显示的标签数量

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -130,6 +130,8 @@ export const siteConfig: SiteConfig = {
 		tagCount: 2,
 		// 文章简介显示行数，设为 0 则不截断
 		descriptionLines: 2,
+		// 文章卡片底部统计和发布日期是否显示图标
+		showStatsIcons: true,
 		// 是否允许用户切换布局
 		allowSwitch: true,
 		// 网格布局配置，仅在 defaultMode 为 "grid" 或允许切换布局时生效

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -127,7 +127,7 @@ export const siteConfig: SiteConfig = {
 		// 是否在文章列表中显示标签
 		showTags: true,
 		// 文章列表中最多显示的标签数量
-		tagCount: 1,
+		tagCount: 2,
 		// 文章简介显示行数，设为 0 则不截断
 		descriptionLines: 2,
 		// 是否允许用户切换布局

--- a/src/types/siteConfig.ts
+++ b/src/types/siteConfig.ts
@@ -100,6 +100,7 @@ export type SiteConfig = {
 		showTags: boolean; // 是否在文章列表中显示标签
 		tagCount?: number; // 文章列表中最多显示的标签数量，默认 1
 		descriptionLines?: number; // 文章简介显示行数，设为 0 则不截断，默认 2
+		showStatsIcons?: boolean; // 文章卡片底部统计是否显示图标
 		allowSwitch: boolean; // 是否允许用户切换布局
 		grid: {
 			// 网格布局配置，仅在 defaultMode 为 "grid" 或允许切换布局时生效

--- a/src/types/siteConfig.ts
+++ b/src/types/siteConfig.ts
@@ -98,6 +98,7 @@ export type SiteConfig = {
 		defaultMode: "list" | "grid"; // 默认布局模式：list=列表模式，grid=网格模式
 		mobileDefaultMode?: "list" | "grid"; // 移动端默认布局模式（视口宽度<780px时使用），不设置则跟随 defaultMode
 		showTags: boolean; // 是否在文章列表中显示标签
+		tagCount?: number; // 文章列表中最多显示的标签数量，默认 1
 		descriptionLines?: number; // 文章简介显示行数，设为 0 则不截断，默认 2
 		allowSwitch: boolean; // 是否允许用户切换布局
 		grid: {


### PR DESCRIPTION
## Summary by Sourcery

优化文章列表卡片的可配置元数据与统计信息展示，并为贡献者撰写仓库约定文档。

New Features:
- 新增可复用的 PostStats 组件，用于渲染发布日期、字数和阅读时间，并可选显示图标。
- 引入配置选项，用于限制每个文章卡片中可见标签的数量，并在文章列表布局中切换统计信息图标的显示。
- 在共享的 PostMeta 组件中支持按需显示发布日期、分类和标签占位符。
- 在现有 Twikoo 和 Waline 集成的基础上，新增对 Artalk 页览量显示的支持。

Enhancements:
- 调整文章列表的网格和列表布局样式，以更好地匹配重新设计的卡片头部元数据。
- 优化 PostCard 布局，将头部信息复用 PostMeta，并将统计信息移入专门的页脚区域。
- 新增 AGENTS.md 文档，说明项目结构、工作流程以及贡献指南。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine post list cards with configurable metadata and stats display, and document repository conventions for contributors.

New Features:
- Add a reusable PostStats component to render publication date, word count, and reading time with optional icons.
- Introduce configuration options to limit visible tags per post card and toggle stats icons in the post list layout.
- Support conditional visibility of published date, category, and tag placeholders in the shared PostMeta component.
- Add Artalk pageview display support alongside existing Twikoo and Waline integrations.

Enhancements:
- Adjust post list grid and list layout styles to better fit the redesigned card header metadata.
- Refine PostCard layout to reuse PostMeta for header info and move stats into a dedicated footer section.
- Add AGENTS.md documenting project structure, workflows, and contribution guidelines.

</details>