### PR TITLE
feat(license): auto switch license icon based on post type

### DIFF
--- a/src/components/misc/License.astro
+++ b/src/components/misc/License.astro
@@ -64,7 +64,7 @@ const postUrl = sourceLink || decodeURIComponent(Astro.url.toString());
     </div>
   </div>
   <Icon is:inline
-    name="fa7-brands:creative-commons"
+    name={(licenseName || licenseConf.name) === "All Rights Reserved" ? "fa7-regular:copyright" : "fa7-brands:creative-commons" }
     class="transition text-[15rem] absolute pointer-events-none right-6 top-1/2 -translate-y-1/2 text-black/5 dark:text-white/5"
   />
 </div>


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

#487 


## Changes

通过三目运算符判断文章许可，如果是 `All Rights Reserved` 就显示对应 icon，否则显示 CC icon。（后续可以写成 i18n key，将 All Rights Reserved 翻译成对应文本如 “保留所有权利”，文章统一写作 `All Rights Reserved`）


## How To Test

- `pnpm check`
- `pnpm format`


## Screenshots (if applicable)

Before:

<img width="910" height="187" alt="image" src="https://github.com/user-attachments/assets/3a3be2c5-67fe-4c8f-b013-9d4d02f472bd" />
After:

<img width="920" height="179" alt="image" src="https://github.com/user-attachments/assets/66a74f8b-ddc2-467f-bfb4-342e2ee60d72" />



## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->

## Summary by Sourcery

新功能：
- 当帖子许可被标记为“保留所有权利”（All Rights Reserved）时显示版权图标，否则回退并显示知识共享（Creative Commons）图标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Display a copyright icon when the post license is marked as All Rights Reserved and fallback to the Creative Commons icon otherwise.

</details>