### PR TITLE
feat: GitHub OAuth 认证系统

### DIFF
--- a/functions/admin/config.yml.js
+++ b/functions/admin/config.yml.js
@@ -1,0 +1,53 @@
+export async function onRequest(context) {
+  const { env, request } = context;
+  const baseUrl = env.BASE_URL || new URL(request.url).origin;
+  const repo = env.GITHUB_REPO || "jeio258/Firefly";
+  const branch = env.GITHUB_BRANCH || "master";
+
+  const config = `
+backend:
+  name: github
+  repo: ${repo}
+  branch: ${branch}
+  base_url: ${baseUrl}
+  auth_endpoint: auth
+
+locale: 'zh'
+site_url: ${baseUrl}
+display_url: ${baseUrl}
+logo_url: ${baseUrl}/favicon.svg
+
+publish_mode: simple
+media_folder: "public/images/posts"
+public_folder: "/images/posts"
+
+collections:
+  - name: "posts"
+    label: "文章"
+    label_singular: "文章"
+    folder: "src/content/posts"
+    create: true
+    slug: "{{slug}}"
+    fields:
+      - { name: "title", label: "标题", widget: "string", required: true }
+      - { name: "pubDate", label: "发布日期", widget: "datetime", format: "yyyy-MM-dd", default: "" }
+      - { name: "tags", label: "标签", widget: "list" }
+      - name: "category"
+        label: "分类"
+        widget: "select"
+        options: ["技术笔记", "生活随笔", "学习记录"]
+        required: false
+      - { name: "description", label: "摘要", widget: "string", required: false }
+      - { name: "published", label: "发布时间", widget: "datetime", format: "yyyy-MM-dd", default: "" }
+      - { name: "draft", label: "草稿模式", widget: "boolean", default: false }
+      - { name: "cover", label: "封面图", widget: "image", required: false }
+      - { name: "body", label: "正文", widget: "markdown", required: true }
+`.trim();
+
+  return new Response(config, {
+    headers: {
+      "Content-Type": "text/yaml; charset=utf-8",
+      "Cache-Control": "no-cache, no-store, must-revalidate"
+    }
+  });
+}

--- a/functions/auth.js
+++ b/functions/auth.js
@@ -1,0 +1,23 @@
+export async function onRequest(context) {
+  const { env, request } = context;
+  const clientId = env.GITHUB_CLIENT_ID;
+  
+  if (!clientId) {
+    return new Response("GITHUB_CLIENT_ID not configured", { status: 500 });
+  }
+
+  const url = new URL(request.url);
+  const redirectUri = `${url.origin}/callback`;
+  
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: "repo,user",
+    state: crypto.randomUUID(),
+  });
+
+  return Response.redirect(
+    `https://github.com/login/oauth/authorize?${params}`,
+    302
+  );
+}

--- a/functions/callback.js
+++ b/functions/callback.js
@@ -1,0 +1,144 @@
+export async function onRequest(context) {
+  const { env, request } = context;
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+
+  if (!code) {
+    return new Response("Missing code", { status: 400 });
+  }
+
+  try {
+    const tokenResponse = await fetch(
+      "https://github.com/login/oauth/access_token",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          client_id: env.GITHUB_CLIENT_ID,
+          client_secret: env.GITHUB_CLIENT_SECRET,
+          code: code,
+          redirect_uri: `${url.origin}/callback`,
+        }),
+      }
+    );
+
+    const data = await tokenResponse.json();
+
+    if (data.error) {
+      return new Response(
+        `Error: ${data.error_description || data.error}`,
+        { status: 400 }
+      );
+    }
+
+    const token = data.access_token;
+    if (!token) {
+      return new Response("No token received", { status: 500 });
+    }
+
+    // 构造返回给 CMS 的消息
+    const content = JSON.stringify({ token, provider: "github" });
+    const successMsg = `authorization:github:success:${content}`;
+    const escapedMsg = successMsg.replace(/"/g, '\\"').replace(/'/g, "\\'");
+
+    const html = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>授权完成</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+      background: #f5f5f5;
+    }
+    .message {
+      text-align: center;
+      padding: 40px;
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    .success { color: #52c41a; font-size: 18px; }
+    .error { color: #ff4d4f; font-size: 18px; }
+  </style>
+</head>
+<body>
+  <div class="message">
+    <p class="success" id="status">✅ 授权成功，正在跳转...</p>
+  </div>
+
+  <script>
+    (function() {
+      const opener = window.opener;
+      const statusEl = document.getElementById('status');
+      
+      if (!opener) {
+        statusEl.className = 'error';
+        statusEl.textContent = '❌ 无法找到主窗口\\n请检查是否被浏览器拦截了弹窗';
+        return;
+      }
+
+      const successMessage = "${escapedMsg}";
+      
+      // 发送握手信号
+      function sendHandshake() {
+        opener.postMessage("authorizing:github", "*");
+      }
+
+      // 监听 CMS 的握手回复
+      function handleReply(event) {
+        if (event.data === "authorizing:github") {
+          window.removeEventListener("message", handleReply);
+          // 收到回复，发送 token
+          opener.postMessage(successMessage, "*");
+          statusEl.textContent = '✅ 授权成功，窗口即将关闭';
+          setTimeout(() => window.close(), 500);
+        }
+      }
+
+      window.addEventListener("message", handleReply);
+
+      // 重试机制：最多尝试 5 次握手
+      let attempts = 0;
+      const maxAttempts = 5;
+      
+      function tryHandshake() {
+        attempts++;
+        sendHandshake();
+        
+        if (attempts < maxAttempts) {
+          setTimeout(tryHandshake, 800);
+        } else {
+          // 降级方案：直接发送 token
+          window.removeEventListener("message", handleReply);
+          opener.postMessage(successMessage, "*");
+          statusEl.textContent = '✅ 授权成功，窗口即将关闭';
+          setTimeout(() => window.close(), 500);
+        }
+      }
+
+      // 页面加载后稍等片刻再开始握手
+      setTimeout(tryHandshake, 300);
+    })();
+  </script>
+</body>
+</html>`;
+
+    return new Response(html, {
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    return new Response(`Server Error: ${error.message}`, { status: 500 });
+  }
+}


### PR DESCRIPTION
- auth.js: OAuth 登录流程
- callback.js: OAuth 回调处理
- admin/config.yml.js: 后台配置接口

## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->


## Changes

<!-- Please describe the changes you made in this pull request. -->


## How To Test

<!-- Please describe how you tested your changes. -->


## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

<!-- Any additional information that you want to share with the reviewer. -->

## Summary by Sourcery

为站点引入基于 GitHub 的 OAuth 认证流程，以及 CMS 配置相关的端点。

新功能：
- 添加认证端点，将用户重定向到 GitHub OAuth 进行身份验证。
- 添加 OAuth 回调端点，用于交换授权码和访问令牌，并返回一个成功页面，通过 postMessage 与 CMS 通信。
- 提供一个动态的 Netlify CMS `config.yml` 端点，根据环境变量来配置 GitHub 仓库、分支和站点 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce GitHub-based OAuth authentication flow and CMS configuration endpoints for the site.

New Features:
- Add auth endpoint that redirects users to GitHub OAuth for authentication.
- Add OAuth callback endpoint that exchanges authorization codes for access tokens and returns a success page that communicates with the CMS via postMessage.
- Expose a dynamic Netlify CMS config.yml endpoint driven by environment variables for GitHub repo, branch, and site URLs.

</details>