### PR TITLE
fix(og): 生成的OpenGraph图片缺少icon图标和avatar头像

### DIFF
--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -53,6 +53,7 @@ export const siteConfig: SiteConfig = {
 	},
 
 	// Favicon 配置
+	// 如果启用了OpenGraph图片功能，数组中需要包含png格式的favicon图标
 	favicon: [
 		{
 			// 图标文件路径

--- a/src/pages/og/[...slug].ts
+++ b/src/pages/og/[...slug].ts
@@ -94,6 +94,83 @@ async function fetchNotoSansSCFonts() {
 	}
 }
 
+// 缓存 sharp 模块，避免在每次 GET 调用中重复动态导入
+let sharpPromise: Promise<typeof import("sharp")["default"]> | null = null;
+function getSharp() {
+	if (!sharpPromise) {
+		sharpPromise = import("sharp").then((m) => m.default);
+	}
+	return sharpPromise;
+}
+
+/**
+ * 获取 1×1 透明 PNG 的 base64 Data URL（兜底图片）。
+ *
+ * 当图片处理失败（如格式不被 sharp 支持）时，使用此透明占位图替代。
+ * 通过 sharp 的 `create` API 生成，懒加载且仅生成一次，结果被缓存。
+ *
+ * @returns `data:image/png;base64,...` 格式的透明 PNG Data URL
+ */
+let transparentPngPromise: Promise<string> | null = null;
+function getTransparentPngBase64(): Promise<string> {
+	if (!transparentPngPromise) {
+		transparentPngPromise = getSharp().then((sharp) =>
+			sharp({
+				create: {
+					width: 1,
+					height: 1,
+					channels: 4,
+					background: { r: 0, g: 0, b: 0, alpha: 0 },
+				},
+			})
+				.png()
+				.toBuffer()
+				.then((buf) => `data:image/png;base64,${buf.toString("base64")}`),
+		);
+	}
+	return transparentPngPromise;
+}
+
+// 已转换图片的缓存（按源路径），避免对同一文件（如头像、站点图标）重复进行 sharp 处理
+const convertedImageCache = new Map<string, string>();
+
+/**
+ * 将图片 Buffer 转换为 PNG base64 Data URL，并缓存结果。
+ *
+ * 以源文件路径作为缓存键，避免对同一图片文件（如头像、站点图标）
+ * 在多次 OG 图片生成中重复进行 sharp 处理。
+ * 若 sharp 无法处理该图片格式，会输出警告并使用透明占位图代替。
+ *
+ * @param imageBuffer - 图片文件的原始 Buffer
+ * @param sourcePath - 图片文件的磁盘路径，用作缓存键
+ * @returns `data:image/png;base64,...` 格式的 PNG Data URL；处理失败时返回透明图
+ */
+async function imageToPngBase64(
+	imageBuffer: Buffer,
+	sourcePath: string,
+): Promise<string> {
+	const cached = convertedImageCache.get(sourcePath);
+	if (cached) return cached;
+
+	const sharp = await getSharp();
+	try {
+		const pngBuffer = await sharp(imageBuffer).png().toBuffer();
+		const result = `data:image/png;base64,${pngBuffer.toString("base64")}`;
+		convertedImageCache.set(sourcePath, result);
+		return result;
+	} catch (err) {
+		console.warn(
+			"\n \x1b[33m[OG Image] Warning \n" +
+				`  无法处理图片 "${sourcePath}"，可能是不被 sharp 支持的图片格式。\n` +
+				"  已使用透明图片替代，请将图片转换为 sharp 支持的格式（PNG/JPEG/WebP/AVIF/TIFF/SVG）。\n" +
+				`  Failed to process image "${sourcePath}", possibly an unsupported image format for sharp.\n` +
+				"  A transparent image was used instead. Please convert it to a sharp-supported format.\n" +
+				`  Error: ${err instanceof Error ? err.message : String(err)}\x1b[0m`,
+		);
+		return getTransparentPngBase64();
+	}
+}
+
 export async function GET({
 	props,
 }: APIContext<{ post: CollectionEntry<"posts"> }>) {
@@ -102,28 +179,32 @@ export async function GET({
 	// Try to fetch fonts from Google Fonts (woff2) at runtime.
 	const { regular: fontRegular, bold: fontBold } = await fetchNotoSansSCFonts();
 
-	// Avatar + icon: still read from disk (small assets)
+	// 头像处理
 	let avatarBase64: string;
-
-	// 检查头像是否为 URL
 	if (profileConfig.avatar?.startsWith("http")) {
-		// 如果是 URL，直接使用
 		avatarBase64 = profileConfig.avatar;
 	} else {
-		// 如果是本地路径，从 public 目录读取
 		const avatarPath = profileConfig.avatar?.startsWith("/")
 			? `./public${profileConfig.avatar}`
 			: `./src/${profileConfig.avatar}`;
-		const avatarBuffer = fs.readFileSync(avatarPath);
-		avatarBase64 = `data:image/png;base64,${avatarBuffer.toString("base64")}`;
+		avatarBase64 = await imageToPngBase64(
+			fs.readFileSync(avatarPath),
+			avatarPath,
+		);
 	}
 
+	// 站点图标处理：优先选择 png 格式的图标，回退到第一个 favicon
 	let iconPath = "./public/favicon/favicon-dark-192.png";
 	if (siteConfig.favicon.length > 0) {
-		iconPath = `./public${siteConfig.favicon[0].src}`;
+		const pngFavicon = siteConfig.favicon.find((f) =>
+			f.src.toLowerCase().endsWith(".png"),
+		);
+		iconPath = `./public${(pngFavicon ?? siteConfig.favicon[0]).src}`;
 	}
-	const iconBuffer = fs.readFileSync(iconPath);
-	const iconBase64 = `data:image/png;base64,${iconBuffer.toString("base64")}`;
+	const iconBase64 = await imageToPngBase64(
+		fs.readFileSync(iconPath),
+		iconPath,
+	);
 
 	const hue = siteConfig.themeColor.hue;
 	const primaryColor = `hsl(${hue}, 90%, 65%)`;
@@ -342,7 +423,7 @@ export async function GET({
 		fonts,
 	});
 
-	const sharp = (await import("sharp")).default;
+	const sharp = await getSharp();
 	const png = await sharp(Buffer.from(svg)).png().toBuffer();
 
 	return new Response(new Uint8Array(png), {


### PR DESCRIPTION
Satori不支持ico和avif格式的图片

https://github.com/vercel/satori/blob/b5c1f64543e5c3b313097795317c618cfeeac8ae/src/handler/image.ts#L68

https://github.com/vercel/satori/blob/b5c1f64543e5c3b313097795317c618cfeeac8ae/src/handler/image.ts#L297-L337

## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

none


## Changes

在将图像传入Satori前，使用Sharp对图像进行预处理，转换成标准png格式


## How To Test

1. 配置`siteConfig.post.generateOgImages`为`true`
2. 运行`pnpm build`
3. 查看`dist`产物
4. og文件夹应包含以下类似的照片，可见图标和头像
<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/0a97bb14-00f6-460c-9d4d-7c27da71393a" />



## Screenshots (if applicable)

none


## Additional Notes

### 变更前后对比

* 修改前
<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/7910e360-4cd2-40fa-9b23-48895ef4e8f0" />

* 修改后
<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/d5c8e103-64b9-455f-bb5f-4147a432d4a7" />

### 注意事项

Sharp和Satori都[不支持ico格式的图像](https://github.com/lovell/sharp/issues/1118)，启用OpenGraph功能时，需要额外添加一张png格式的favicon图像，否则控制台会输出以下警告：

```
21:31:12   ├─ /guestbook/index.html (+18ms) 
21:31:12   ├─ /og/code-examples.png/
 [OG Image] Warning 
  无法处理图片 "./public/favicon/favicon.ico"，可能是不被 sharp 支持的图片格式。
  已使用透明图片替代，请将图片转换为 sharp 支持的格式（PNG/JPEG/WebP/AVIF/TIFF/SVG）。
  Failed to process image "./public/favicon/favicon.ico", possibly an unsupported image format for sharp.
  A transparent image was used instead. Please convert it to a sharp-supported format.
  Error: Input buffer contains unsupported image format
 (+2.75s) 
```

## Summary by Sourcery

将 OG 头像和 favicon 图像预处理为与 Satori 兼容的 PNG 格式，并确保对不受支持的图像类型提供可靠的回退方案。

Bug Fixes:
- 修复当源资源使用 Satori 或 sharp 不支持的格式时，生成的 OpenGraph 图像中缺失头像和图标的问题。

Enhancements:
- 引入共享的 sharp 加载器、透明 PNG 回退方案，并对转换后的图像进行缓存，以避免重复处理。
- 在 OG 生成中优先使用 PNG 格式的 favicon 资源，并在文档中说明当启用 OpenGraph 图像生成功能时需要提供 PNG 图标。

Documentation:
- 在站点配置文档中注明：当启用 OpenGraph 图像生成功能时，需要提供 PNG 格式的 favicon。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preprocess OG avatar and favicon images into PNG format compatible with Satori and ensure robust fallbacks for unsupported image types.

Bug Fixes:
- Fix missing avatar and icon in generated OpenGraph images when source assets use formats unsupported by Satori or sharp.

Enhancements:
- Introduce shared sharp loader, transparent PNG fallback, and caching of converted images to avoid redundant processing.
- Prefer PNG favicon assets for OG generation and document the need for a PNG icon when OpenGraph image generation is enabled.

Documentation:
- Document in site configuration that a PNG favicon is required when OpenGraph image generation is enabled.

</details>