### PR TITLE
fix: 解决mermaid显示问题

### DIFF
--- a/src/styles/markdown-extend.styl
+++ b/src/styles/markdown-extend.styl
@@ -296,7 +296,6 @@ a.card-github.fetch-error
     border-radius: 0.5rem
     user-select: none
     transition: transform 0.12s ease-out
-    will-change: transform
 
 // 深色/浅色 SVG 主题切换
 .mermaid-svg-dark
@@ -355,7 +354,6 @@ a.card-github.fetch-error
   user-select: none
   -webkit-user-drag: none
   transition: transform 0.12s ease-out
-  will-change: transform
 
 .plantuml-error
   color: var(--admonitions-color-warning)
@@ -391,7 +389,8 @@ a.card-github.fetch-error
     filter: brightness(0.95)
 
 @media (max-width: 768px)
-  .mermaid-svg svg
+  .mermaid-svg-light svg,
+  .mermaid-svg-dark svg
     max-height: 400px
 
   .plantuml-image
@@ -469,7 +468,6 @@ a.card-github.fetch-error
     max-height: 100%
     user-select: none
     -webkit-user-drag: none
-    will-change: transform
 
 .diagram-fs-controls
   position: fixed


### PR DESCRIPTION
…iagrams

## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

#507 

## Changes

仅仅修改了`src\styles\markdown-extend.styl` 调整了格式,默认从头最上方开始,之前的会导致看不清,包括放大,文字会像马赛克一样(看了下是因为之前的:`will-change: transform`)

## Summary by Sourcery

调整图表样式，以提升 Mermaid 和 PlantUML 图表在不同视口下的可读性和布局表现。

Bug 修复：
- 确保 Mermaid 图表从顶部对齐，并限定在固定高度的容器内，避免渲染不清晰和内容被裁剪的问题。
- 移除对 Mermaid 和 PlantUML 图像过于激进的 transform 优化和高度限制，以防在缩放或调整图表大小时出现文字模糊、像素化的情况。
- 放宽移动端对图表的最大高度限制，使图表能够完整显示，避免被意外截断。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust diagram styling to improve Mermaid and PlantUML diagram readability and layout across viewports.

Bug Fixes:
- Ensure Mermaid diagrams are aligned from the top and constrained within a fixed-height container to avoid unclear rendering and clipping issues.
- Remove aggressive transform optimizations and height limits from Mermaid and PlantUML images to prevent blurry, pixelated text when zooming or scaling diagrams.
- Relax mobile max-height constraints for diagrams so they can display fully without unintended truncation.

</details>