### PR TITLE
fix: 修复navBar配置项中文注释错误

### DIFF
--- a/src/config/navBarConfig.ts
+++ b/src/config/navBarConfig.ts
@@ -42,10 +42,10 @@ const getDynamicNavBarConfig = (): NavBarConfig => {
 		url: "#",
 		icon: "material-symbols:group",
 		children: [
-			// 相册
+			// 友链
 			LinkPresets.Friends,
 
-			// 追番
+			// 留言
 			LinkPresets.Guestbook,
 		],
 	});


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

## Changes

就这一个文件,单纯注释写错了
<img width="785" height="254" alt="image" src="https://github.com/user-attachments/assets/c2c9aea7-a25a-47b6-83e5-87a757e7433b" />

## Summary by Sourcery

增强内容：
- 更新导航栏项目的注释，以准确描述 Friends 和 Guestbook 链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update nav bar item comments to accurately describe the Friends and Guestbook links.

</details>