### PR TITLE
将原本在astro文件里的bangumi展示配置项放到config文件里面

### DIFF
--- a/src/config/navBarConfig.ts
+++ b/src/config/navBarConfig.ts
@@ -42,10 +42,10 @@ const getDynamicNavBarConfig = (): NavBarConfig => {
 		url: "#",
 		icon: "material-symbols:group",
 		children: [
-			// 相册
+			// 友链
 			LinkPresets.Friends,
 
-			// 追番
+			// 留言
 			LinkPresets.Guestbook,
 		],
 	});

--- a/src/config/siteConfig.ts
+++ b/src/config/siteConfig.ts
@@ -207,6 +207,10 @@ export const siteConfig: SiteConfig = {
 		// 可选值: "anime" | "book" | "music" | "game" | "real" (暂不支持"real"类型)
 		// 未列出的类型将按默认顺序排在后面
 		categoryOrder: ["anime", "book", "music", "game"],
+		// 控制各分类的启用状态（true/false），未指定的分类默认启用
+		// categories: {
+		// 	game: false, // 禁用游戏分类显示
+		// },
 	},
 
 	// 追番配置（Bilibili + TMDB）

--- a/src/pages/bangumi.astro
+++ b/src/pages/bangumi.astro
@@ -28,12 +28,13 @@ const bangumiConfig = {
 	apiUrl: siteConfig.bangumi?.apiUrl || "https://api.bangumi.one",
 	subjectBaseUrl:
 		siteConfig.bangumi?.subjectBaseUrl || "https://bangumi.one/subject/",
+	// 从配置文件中读取各分类是否启用，若未配置则使用默认值
 	categories: {
-		book: true,
-		anime: true,
-		music: true,
-		game: true,
-		real: false,
+		book: siteConfig.bangumi?.categories?.book ?? true,
+		anime: siteConfig.bangumi?.categories?.anime ?? true,
+		music: siteConfig.bangumi?.categories?.music ?? true,
+		game: siteConfig.bangumi?.categories?.game ?? true,
+		real: siteConfig.bangumi?.categories?.real ?? false,
 	},
 	// 数据获取设置
 	pagination: {

--- a/src/types/siteConfig.ts
+++ b/src/types/siteConfig.ts
@@ -151,6 +151,14 @@ export type SiteConfig = {
 		apiUrl?: string; // Bangumi API 地址
 		subjectBaseUrl?: string; // 条目详情页地址
 		categoryOrder?: ("anime" | "game" | "book" | "music" | "real")[]; // 条目类型排序顺序
+		// 各分类的显示启用状态，未设置时默认启用
+		categories?: {
+			book?: boolean;
+			anime?: boolean;
+			music?: boolean;
+			game?: boolean;
+			real?: boolean;
+		};
 	};
 
 	// 追番配置（Bilibili + TMDB）


### PR DESCRIPTION
## Type of change

- [x] New feature (a non-breaking change that adds functionality)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Changes

修改了
- `src/config/siteConfig.ts` 添加example(已注释掉,如果需要禁用某一类别请取消注释)
- `src/pages/bangumi.astro` 从配置文件读取
- `src/types/siteConfig.ts` 添加是否显示类型为bool
```typescript
// 控制各分类的启用状态（true/false），未指定的分类默认启用
// categories: {
// 	game: false, // 禁用游戏分类显示
// },
```

效果等同于直接改原本的`src/pages/bangumi.astro`文件,将`categories.game`:`true`->`false`

## How To Test

如上取消注释掉`src/config/siteConfig.ts`里的`categories`即可

## Screenshots (if applicable)

<img width="698" height="495" alt="image" src="https://github.com/user-attachments/assets/50544574-bb21-425b-81a7-333119764293" />


## Additional Notes

其实就是把配置项放到了config里面,方便修改(bangumi里太多galgame不方便展示就想到取消展示game界面,不过config里面一直找不到)

## Summary by Sourcery

通过共享站点配置，使 Bangumi 分类的可见性可配置。

新功能：
- 允许通过 `siteConfig` 启用或禁用单个 Bangumi 分类，而不是在 bangumi 页面中将其硬编码。

改进：
- 扩展 Bangumi 站点配置类型，添加可选的分类可见性标记，以支持新的可配置功能。
- 明确导航栏子链接的注释，使其更好地反映实际用途。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make Bangumi category visibility configurable via the shared site configuration.

New Features:
- Allow enabling or disabling individual Bangumi categories through siteConfig instead of hardcoding them in the bangumi page.

Enhancements:
- Extend the Bangumi site configuration type with optional category visibility flags to support the new configurability.
- Clarify nav bar child link comments to better reflect their purpose.

</details>