### PR TITLE
bug: 添加播放音乐失败逻辑,自动播放下一首

### DIFF
--- a/src/components/features/MusicManager.astro
+++ b/src/components/features/MusicManager.astro
@@ -200,23 +200,20 @@ const managerConfigStr = JSON.stringify({
         }
     }
 
-    // ── Track loading ────────────────────────────────────────
-    function loadTrack(index, autoPlay) {
-        if (index < 0 || index >= state.playlist.length) return;
-        state.currentIndex = index;
-        var track = state.playlist[index];
-        var ver = ++loadVersion;
+    var currentTrackUrls = [];
+    var currentTrackUrlIndex = 0;
+    var errorSkipTimeout = null;
 
-        audio.src = track.url;
-
-        loadLyrics(track);
-
-        emit('fm:track', { index: index, track: track, autoPlay: !!autoPlay });
+    function tryPlayCurrentTrackUrl(autoPlay, ver) {
+        if (ver !== loadVersion) return;
+        var playUrl = currentTrackUrls[currentTrackUrlIndex];
+        audio.src = playUrl;
 
         if (autoPlay) {
             audio.play().then(function () {
                 if (ver !== loadVersion) return; // stale, discard
                 state.isPlaying = true;
+                state.error = null;
                 emit('fm:play-state', { isPlaying: true });
             }).catch(function (e) {
                 if (ver !== loadVersion) return; // stale, discard
@@ -229,12 +226,51 @@ const managerConfigStr = JSON.stringify({
         }
     }
 
+    // ── Track loading ────────────────────────────────────────
+    function loadTrack(index, autoPlay) {
+        if (index < 0 || index >= state.playlist.length) return;
+        state.currentIndex = index;
+        var track = state.playlist[index];
+        var ver = ++loadVersion;
+
+        if (errorSkipTimeout) {
+            clearTimeout(errorSkipTimeout);
+            errorSkipTimeout = null;
+        }
+
+        currentTrackUrls = [track.url];
+        currentTrackUrlIndex = 0;
+
+        var matchId = track.url.match(/[?&]id=([^&]+)/);
+        var matchServer = track.url.match(/[?&]server=([^&]+)/);
+        if (matchId && matchServer && config.meting && config.meting.fallbackApis) {
+            config.meting.fallbackApis.forEach(function (fallback) {
+                var fallbackUrl = fallback
+                    .replace(':server', matchServer[1])
+                    .replace(':type', 'url')
+                    .replace(':id', matchId[1]);
+                if (currentTrackUrls.indexOf(fallbackUrl) === -1) {
+                    currentTrackUrls.push(fallbackUrl);
+                }
+            });
+        }
+
+        loadLyrics(track);
+
+        emit('fm:track', { index: index, track: track, autoPlay: !!autoPlay });
+
+        tryPlayCurrentTrackUrl(autoPlay, ver);
+    }
+
     // ── Playback controls ────────────────────────────────────
     function togglePlay() {
         if (audio.paused) {
             audio.play().then(function () {
                 state.isPlaying = true;
                 emit('fm:play-state', { isPlaying: true });
+            }).catch(function (e) {
+                if (e.name === 'AbortError') return;
+                console.warn('Playback failed:', e);
             });
         } else {
             audio.pause();
@@ -345,8 +381,22 @@ const managerConfigStr = JSON.stringify({
     });
 
     audio.addEventListener('error', function () {
-        state.error = 'Audio playback error';
-        emit('fm:error', { message: state.error });
+        var ver = loadVersion;
+        if (currentTrackUrlIndex < currentTrackUrls.length - 1) {
+            currentTrackUrlIndex++;
+            console.warn('Playback failed, trying fallback URL: ' + currentTrackUrls[currentTrackUrlIndex]);
+            tryPlayCurrentTrackUrl(true, ver);
+        } else {
+            state.error = 'Audio playback error';
+            emit('fm:error', { message: '播放失败，即将自动跳过...' });
+
+            if (errorSkipTimeout) clearTimeout(errorSkipTimeout);
+            errorSkipTimeout = setTimeout(function () {
+                if (ver === loadVersion) {
+                    playNext(true);
+                }
+            }, 2000);
+        }
     });
 
     // ── Init (idempotent) ────────────────────────────────────

--- a/src/config/navBarConfig.ts
+++ b/src/config/navBarConfig.ts
@@ -42,10 +42,10 @@ const getDynamicNavBarConfig = (): NavBarConfig => {
 		url: "#",
 		icon: "material-symbols:group",
 		children: [
-			// 相册
+			// 友链
 			LinkPresets.Friends,
 
-			// 追番
+			// 留言
 			LinkPresets.Guestbook,
 		],
 	});


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

#512 

## Changes

修改了`src\components\features\MusicManager.astro`
添加了错误处理机制以及自动播放下一首歌

## How To Test

找一首播放不了的歌曲,之后会发现自动跳转下一首以及F12报错
<img width="709" height="80" alt="image" src="https://github.com/user-attachments/assets/89b7e289-2a51-4615-bfb1-5b99ae3518d4" />


## Screenshots (if applicable)
效果如图
<img width="462" height="316" alt="play error gif" src="https://github.com/user-attachments/assets/c42bf224-1dce-4d3a-bc2a-60d7ce5528fa" />

## Summary by Sourcery

通过处理音频错误并自动跳过无法播放的曲目来提升音乐播放的健壮性。

Bug Fixes:
- 确保当某个曲目播放失败时，会触发错误上报并自动跳到下一首曲目。

Enhancements:
- 为每个曲目引入备用音频 URL，在发生错误时先重试播放再考虑跳过。
- 在播放成功后重置错误状态，并为播放失败添加控制台日志输出。
- 在连续播放错误后加入延时自动跳过行为，避免播放器卡在损坏的曲目上。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve music playback resilience by handling audio errors and automatically skipping tracks that fail to play.

Bug Fixes:
- Ensure playback failures on a track trigger error reporting and automatic skip to the next track.

Enhancements:
- Introduce fallback audio URLs per track and retry playback on errors before skipping.
- Reset error state on successful playback and add console logging for playback failures.
- Add delayed auto-skip behavior after repeated playback errors to avoid getting stuck on broken tracks.

</details>