### PR TITLE
fix: 改善键盘焦点导航与浮层状态同步

### DIFF
--- a/src/components/common/ButtonLink.astro
+++ b/src/components/common/ButtonLink.astro
@@ -12,6 +12,7 @@ const { badge, url, label } = Astro.props;
     class:list={`
             flex
             items-center
+            focus-ring-inset
             w-full
             h-10
             rounded-lg
@@ -43,9 +44,3 @@ const { badge, url, label } = Astro.props;
         }
     </div>
 </a>
-
-<style>
-	a:focus-visible {
-		outline-offset: -2px;
-	}
-</style>

--- a/src/components/common/ButtonLink.astro
+++ b/src/components/common/ButtonLink.astro
@@ -6,9 +6,12 @@ interface Props {
 }
 const { badge, url, label } = Astro.props;
 ---
-<a href={url} aria-label={label}>
-    <button
-        class:list={`
+<a
+    href={url}
+    aria-label={label}
+    class:list={`
+            flex
+            items-center
             w-full
             h-10
             rounded-lg
@@ -24,20 +27,25 @@ const { badge, url, label } = Astro.props;
             dark:text-neutral-300
             dark:hover:text-(--primary)
         `
-        }
-    >
-        <div class="flex items-center justify-between relative mr-2">
-            <div class="overflow-hidden text-left whitespace-nowrap text-ellipsis  ">
-                <slot></slot>
-            </div>
-            { badge !== undefined && badge !== null && badge !== '' &&
-                <div class="transition px-2 h-7 ml-4 min-w-8 rounded-lg text-sm font-bold
-                    text-(--btn-content) dark:text-(--deep-text)
-                    bg-[oklch(0.95_0.025_var(--hue))] dark:bg-(--primary)
-                    flex items-center justify-center">
-                    { badge }
-                </div>
-            }
+    }
+>
+    <div class="flex w-full min-w-0 items-center justify-between relative mr-2">
+        <div class="overflow-hidden text-left whitespace-nowrap text-ellipsis">
+            <slot></slot>
         </div>
-    </button>
+        { badge !== undefined && badge !== null && badge !== '' &&
+            <div class="transition px-2 h-7 ml-4 min-w-8 rounded-lg text-sm font-bold
+                text-(--btn-content) dark:text-(--deep-text)
+                bg-[oklch(0.95_0.025_var(--hue))] dark:bg-(--primary)
+                flex items-center justify-center">
+                { badge }
+            </div>
+        }
+    </div>
 </a>
+
+<style>
+	a:focus-visible {
+		outline-offset: -2px;
+	}
+</style>

--- a/src/components/controls/DisplaySettingsIntegrated.svelte
+++ b/src/components/controls/DisplaySettingsIntegrated.svelte
@@ -599,13 +599,13 @@ $effect(() => {
 </script>
 
 {#if hasAnyContent}
-<div id="display-setting" class="float-panel float-panel-closed absolute transition-all w-80 right-4 px-3 pt-0 pb-3 max-h-[80vh] overflow-y-auto">
+<div id="display-setting" class="float-panel float-panel-closed absolute transition-all w-80 right-4 px-3 pt-0 pb-3 max-h-[80vh] overflow-y-auto" data-floating-panel data-floating-panel-trigger="display-settings-switch" inert aria-hidden="true">
 	<!-- Tab Bar -->
 	{#if showTabBar}
 	<div class="flex border-b border-black/5 dark:border-white/10 -mx-1 mb-2">
 		{#each visibleTabs as tab (tab.key)}
 			<button
-				class="flex-1 flex items-center justify-center gap-1 py-2 text-xs font-medium transition-colors relative min-w-0
+				class="settings-tab flex-1 flex items-center justify-center gap-1 py-2 text-xs font-medium transition-colors relative min-w-0 rounded-md
 					{activeTab === tab.key ? 'text-(--primary)' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
 				onclick={() => activeTab = tab.key}
 			>
@@ -627,7 +627,8 @@ $effect(() => {
 			<div class="section-title">
 				{i18n(I18nKey.themeColor)}
 				<button aria-label="Reset to Default" class="btn-regular rounded-md active:scale-90"
-						class:opacity-0={hue === defaultHue} class:pointer-events-none={hue === defaultHue} onclick={resetHue}>
+						class:opacity-0={hue === defaultHue} class:pointer-events-none={hue === defaultHue}
+						disabled={hue === defaultHue} aria-hidden={hue === defaultHue ? "true" : undefined} onclick={resetHue}>
 					<div class="text-(--btn-content)">
 						<Icon icon="fa7-solid:arrow-rotate-left" class="text-[0.75rem]"></Icon>
 					</div>
@@ -637,7 +638,7 @@ $effect(() => {
 					{hue}
 				</div>
 			</div>
-			<div class="w-full h-6 px-1 bg-[oklch(0.80_0.10_0)] dark:bg-[oklch(0.70_0.10_0)] rounded-sm select-none">
+			<div class="hue-slider-shell w-full h-6 px-1 bg-[oklch(0.80_0.10_0)] dark:bg-[oklch(0.70_0.10_0)] rounded-md select-none">
 				<input aria-label={i18n(I18nKey.themeColor)} type="range" min="0" max="360" bind:value={hue}
 					   class="slider" id="colorSlider" step="5" style="width: 100%">
 			</div>
@@ -650,7 +651,8 @@ $effect(() => {
 			<div class="section-title">
 				{i18n(I18nKey.postListLayout)}
 				<button aria-label="Reset to Default" class="btn-regular rounded-md active:scale-90"
-						class:opacity-0={currentLayout === effectiveDefaultLayout} class:pointer-events-none={currentLayout === effectiveDefaultLayout} onclick={resetLayout}>
+						class:opacity-0={currentLayout === effectiveDefaultLayout} class:pointer-events-none={currentLayout === effectiveDefaultLayout}
+						disabled={currentLayout === effectiveDefaultLayout} aria-hidden={currentLayout === effectiveDefaultLayout ? "true" : undefined} onclick={resetLayout}>
 					<div class="text-(--btn-content)">
 						<Icon icon="fa7-solid:arrow-rotate-left" class="text-[0.75rem]"></Icon>
 					</div>
@@ -695,7 +697,8 @@ $effect(() => {
 			<div class="section-title">
 				{i18n(I18nKey.cardSettings)}
 				<button aria-label="Reset to Default" class="btn-regular rounded-md active:scale-90"
-						class:opacity-0={cardSettingsIsDefault} class:pointer-events-none={cardSettingsIsDefault} onclick={resetCardSettings}>
+						class:opacity-0={cardSettingsIsDefault} class:pointer-events-none={cardSettingsIsDefault}
+						disabled={cardSettingsIsDefault} aria-hidden={cardSettingsIsDefault ? "true" : undefined} onclick={resetCardSettings}>
 					<div class="text-(--btn-content)">
 						<Icon icon="fa7-solid:arrow-rotate-left" class="text-[0.75rem]"></Icon>
 					</div>
@@ -749,7 +752,8 @@ $effect(() => {
 			<div class="section-title">
 				{i18n(I18nKey.wallpaperMode)}
 				<button aria-label="Reset to Default" class="btn-regular rounded-md active:scale-90"
-						class:opacity-0={wallpaperMode === defaultWallpaperMode} class:pointer-events-none={wallpaperMode === defaultWallpaperMode} onclick={resetWallpaperMode}>
+						class:opacity-0={wallpaperMode === defaultWallpaperMode} class:pointer-events-none={wallpaperMode === defaultWallpaperMode}
+						disabled={wallpaperMode === defaultWallpaperMode} aria-hidden={wallpaperMode === defaultWallpaperMode ? "true" : undefined} onclick={resetWallpaperMode}>
 					<div class="text-(--btn-content)">
 						<Icon icon="fa7-solid:arrow-rotate-left" class="text-[0.75rem]"></Icon>
 					</div>
@@ -802,7 +806,8 @@ $effect(() => {
 			<div class="section-title">
 				{i18n(I18nKey.overlaySettings)}
 				<button aria-label="Reset to Default" class="btn-regular rounded-md active:scale-90"
-						class:opacity-0={overlaySettingsIsDefault} class:pointer-events-none={overlaySettingsIsDefault} onclick={resetOverlaySettings}>
+						class:opacity-0={overlaySettingsIsDefault} class:pointer-events-none={overlaySettingsIsDefault}
+						disabled={overlaySettingsIsDefault} aria-hidden={overlaySettingsIsDefault ? "true" : undefined} onclick={resetOverlaySettings}>
 					<div class="text-(--btn-content)">
 						<Icon icon="fa7-solid:arrow-rotate-left" class="text-[0.75rem]"></Icon>
 					</div>
@@ -839,7 +844,8 @@ $effect(() => {
 			<div class="section-title">
 				{i18n(I18nKey.wallpaperSettings)}
 				<button aria-label="Reset to Default" class="btn-regular rounded-md active:scale-90"
-						class:opacity-0={bannerSettingsIsDefault} class:pointer-events-none={bannerSettingsIsDefault} onclick={resetBannerSettings}>
+						class:opacity-0={bannerSettingsIsDefault} class:pointer-events-none={bannerSettingsIsDefault}
+						disabled={bannerSettingsIsDefault} aria-hidden={bannerSettingsIsDefault ? "true" : undefined} onclick={resetBannerSettings}>
 					<div class="text-(--btn-content)">
 						<Icon icon="fa7-solid:arrow-rotate-left" class="text-[0.75rem]"></Icon>
 					</div>
@@ -930,7 +936,9 @@ $effect(() => {
 			<div class="section-title">
 				{i18n(I18nKey.effectsSettings)}
 				<button aria-label="Reset to Default" class="btn-regular rounded-md active:scale-90"
-						class:opacity-0={sakuraEnabled === defaultSakuraEnabled} class:pointer-events-none={sakuraEnabled === defaultSakuraEnabled} onclick={() => { sakuraEnabled = defaultSakuraEnabled; setSakuraEnabled(defaultSakuraEnabled); }}>
+						class:opacity-0={sakuraEnabled === defaultSakuraEnabled} class:pointer-events-none={sakuraEnabled === defaultSakuraEnabled}
+						disabled={sakuraEnabled === defaultSakuraEnabled} aria-hidden={sakuraEnabled === defaultSakuraEnabled ? "true" : undefined}
+						onclick={() => { sakuraEnabled = defaultSakuraEnabled; setSakuraEnabled(defaultSakuraEnabled); }}>
 					<div class="text-(--btn-content)">
 						<Icon icon="fa7-solid:arrow-rotate-left" class="text-[0.75rem]"></Icon>
 					</div>

--- a/src/components/controls/DisplaySettingsIntegrated.svelte
+++ b/src/components/controls/DisplaySettingsIntegrated.svelte
@@ -605,7 +605,7 @@ $effect(() => {
 	<div class="flex border-b border-black/5 dark:border-white/10 -mx-1 mb-2">
 		{#each visibleTabs as tab (tab.key)}
 			<button
-				class="settings-tab flex-1 flex items-center justify-center gap-1 py-2 text-xs font-medium transition-colors relative min-w-0 rounded-md
+				class="focus-ring-inset flex-1 flex items-center justify-center gap-1 py-2 text-xs font-medium transition-colors relative min-w-0 rounded-md
 					{activeTab === tab.key ? 'text-(--primary)' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'}"
 				onclick={() => activeTab = tab.key}
 			>

--- a/src/components/controls/LightDarkSwitch.svelte
+++ b/src/components/controls/LightDarkSwitch.svelte
@@ -116,7 +116,7 @@ onMount(() => {
 </script>
 
 <div class="relative z-50">
-    <button aria-label="Light/Dark Mode" aria-haspopup="menu" class="relative btn-plain scale-animation rounded-lg h-9 w-9 md:h-11 md:w-11 active:scale-90" id="scheme-switch">
+	<button aria-label="Light/Dark Mode" aria-haspopup="menu" aria-controls="theme-mode-panel" aria-expanded="false" class="relative btn-plain scale-animation rounded-lg h-9 w-9 md:h-11 md:w-11 active:scale-90" id="scheme-switch">
         <div class="absolute inset-0 flex items-center justify-center" class:opacity-0={displayedMode !== LIGHT_MODE}>
             <Icon icon="material-symbols:wb-sunny-outline-rounded" class="text-[1.25rem]"></Icon>
         </div>
@@ -124,7 +124,7 @@ onMount(() => {
             <Icon icon="material-symbols:dark-mode-outline-rounded" class="text-[1.25rem]"></Icon>
         </div>
     </button>
-    <div id="theme-mode-panel" class="absolute transition float-panel-closed top-11 -right-2 pt-5 z-50" role="menu" aria-labelledby="scheme-switch">
+    <div id="theme-mode-panel" class="absolute transition float-panel-closed top-11 -right-2 pt-5 z-50" role="menu" aria-labelledby="scheme-switch" data-floating-panel data-floating-panel-trigger="scheme-switch" inert aria-hidden="true">
         <DropdownPanel>
             <DropdownItem
                 role="menuitem"

--- a/src/components/controls/Search.svelte
+++ b/src/components/controls/Search.svelte
@@ -5,6 +5,7 @@ import { navigateToPage } from "@utils/navigation-utils";
 import { onMount } from "svelte";
 import Icon from "@/components/common/Icon.svelte";
 import type { SearchResult } from "@/global";
+import { FLOATING_PANEL_CLOSE_EVENT } from "@/utils/floating-panel-utils";
 import { url as formatUrl, getSearchUrl } from "@/utils/url-utils";
 
 // --- State ---
@@ -14,6 +15,7 @@ let result: SearchResult[] = [];
 let isSearching = false;
 let initialized = false;
 let debounceTimer: NodeJS.Timeout;
+let searchRequestId = 0;
 
 // --- Mocks for Dev Mode ---
 const fakeResult: SearchResult[] = [
@@ -37,6 +39,17 @@ const togglePanel = () => {
 		?.classList.toggle("float-panel-closed");
 };
 
+const handleDesktopFocus = (event: FocusEvent): void => {
+	const input = event.currentTarget;
+	if (
+		input instanceof HTMLElement &&
+		input.hasAttribute("data-floating-panel-focus-return")
+	)
+		return;
+
+	search(keywordDesktop, true);
+};
+
 const setPanelVisibility = (show: boolean, isDesktop: boolean): void => {
 	const panel = document.getElementById("search-panel");
 	if (
@@ -57,6 +70,12 @@ const closeSearchPanel = (): void => {
 	result = [];
 };
 
+const cancelPendingSearch = (): void => {
+	clearTimeout(debounceTimer);
+	searchRequestId += 1;
+	isSearching = false;
+};
+
 const handleResultClick = (event: Event, url: string): void => {
 	event.preventDefault();
 	closeSearchPanel();
@@ -66,15 +85,17 @@ const handleResultClick = (event: Event, url: string): void => {
 // --- Core Search Logic ---
 const search = async (keyword: string, isDesktop: boolean): Promise<void> => {
 	if (!keyword) {
+		cancelPendingSearch();
 		setPanelVisibility(false, isDesktop);
 		result = [];
 		return;
 	}
 	if (!initialized) return;
 
+	clearTimeout(debounceTimer);
+	const requestId = ++searchRequestId;
 	isSearching = true;
 
-	clearTimeout(debounceTimer);
 	debounceTimer = setTimeout(async () => {
 		try {
 			let searchResults: SearchResult[] = [];
@@ -88,14 +109,20 @@ const search = async (keyword: string, isDesktop: boolean): Promise<void> => {
 				searchResults = fakeResult;
 			}
 
+			if (requestId !== searchRequestId) return;
+
 			result = searchResults;
 			setPanelVisibility(true, isDesktop);
 		} catch (error) {
+			if (requestId !== searchRequestId) return;
+
 			console.error("Search error:", error);
 			result = [];
 			setPanelVisibility(false, isDesktop);
 		} finally {
-			isSearching = false;
+			if (requestId === searchRequestId) {
+				isSearching = false;
+			}
 		}
 	}, 300); // 300ms debounce
 };
@@ -125,6 +152,16 @@ onMount(() => {
 			});
 		}
 	}
+
+	const panel = document.getElementById("search-panel");
+	panel?.addEventListener(FLOATING_PANEL_CLOSE_EVENT, cancelPendingSearch);
+
+	return () => {
+		panel?.removeEventListener(FLOATING_PANEL_CLOSE_EVENT, cancelPendingSearch);
+		document.removeEventListener("pagefindready", initializePagefind);
+		document.removeEventListener("pagefindloaderror", initializePagefind);
+		cancelPendingSearch();
+	};
 });
 
 // --- Reactive Statements ---
@@ -143,22 +180,24 @@ $: if (initialized && (keywordMobile || keywordMobile === "")) {
 ">
     <Icon icon="material-symbols:search"
           class="absolute text-[1.25rem] pointer-events-none ml-3 transition my-auto text-black/30 dark:text-white/30"></Icon>
-    <input placeholder="{i18n(I18nKey.search)}" bind:value={keywordDesktop}
-           on:focus={() => search(keywordDesktop, true)}
+    <input id="search-input-desktop" placeholder="{i18n(I18nKey.search)}" bind:value={keywordDesktop}
+           aria-controls="search-panel" data-floating-panel-no-expanded
+           on:focus={handleDesktopFocus}
            class="transition-all pl-10 text-sm bg-transparent outline-0
          h-full w-40 active:w-60 focus:w-60 text-black/50 dark:text-white/50"
     >
 </div>
 
 <!-- toggle btn for phone/tablet view -->
-<button on:click={togglePanel} aria-label="Search Panel" id="search-switch"
-        class="btn-plain scale-animation lg:hidden! rounded-lg w-9 h-9 md:w-11 md:h-11 active:scale-90">
+<button on:click={togglePanel} aria-label="Search Panel" aria-controls="search-panel" aria-expanded="false" id="search-switch"
+		class="btn-plain scale-animation lg:hidden! rounded-lg w-9 h-9 md:w-11 md:h-11 active:scale-90">
     <Icon icon="material-symbols:search" class="text-[1.25rem]"></Icon>
 </button>
 
 <!-- search panel -->
 <div id="search-panel" class="float-panel float-panel-closed search-panel absolute md:w-120
-top-20 left-4 md:left-[unset] right-4 shadow-2xl rounded-2xl p-2">
+top-20 left-4 md:left-[unset] right-4 shadow-2xl rounded-2xl p-2"
+     data-floating-panel data-floating-panel-trigger="search-switch search-input-desktop" inert aria-hidden="true">
 
     <!-- search bar inside panel for phone/tablet -->
     <div id="search-bar-inside" class="flex relative lg:hidden transition-all items-center h-11 rounded-xl
@@ -240,4 +279,3 @@ top-20 left-4 md:left-[unset] right-4 shadow-2xl rounded-2xl p-2">
         overflow-y: auto;
     }
 </style>
-

--- a/src/components/layout/CategoryBar.astro
+++ b/src/components/layout/CategoryBar.astro
@@ -113,6 +113,9 @@ function initialActive(categoryName: string): {
   .category-bar .category-pill {
     border: none;
   }
+  .category-bar .category-pill:focus-visible {
+    outline-offset: -2px;
+  }
   .category-bar {
     margin-bottom: 1rem;
   }

--- a/src/components/layout/CategoryBar.astro
+++ b/src/components/layout/CategoryBar.astro
@@ -51,7 +51,7 @@ function initialActive(categoryName: string): {
   <div class="category-bar-inner flex gap-2">
     <a
       href={homeUrl}
-      class="category-pill text-sm px-3 py-1.5 rounded-full shrink-0
+      class="category-pill focus-ring-inset text-sm px-3 py-1.5 rounded-full shrink-0
              transition-colors duration-150 ease-out flex items-center justify-center"
       data-category-name=""
       data-active={initialActive("").active ? "" : undefined}
@@ -61,7 +61,7 @@ function initialActive(categoryName: string): {
     </a>
     <a
       href={archiveUrl}
-      class="category-pill text-sm px-4 py-1.5 rounded-full whitespace-nowrap shrink-0
+      class="category-pill focus-ring-inset text-sm px-4 py-1.5 rounded-full whitespace-nowrap shrink-0
              transition-colors duration-150 ease-out flex items-center justify-center"
       data-category-name="__archive__"
       data-active={initialActive("__archive__").active ? "" : undefined}
@@ -79,7 +79,7 @@ function initialActive(categoryName: string): {
             return (
             <a
               href={cat.url}
-              class="category-pill text-sm px-4 py-1.5 rounded-full whitespace-nowrap
+              class="category-pill focus-ring-inset text-sm px-4 py-1.5 rounded-full whitespace-nowrap
                      transition-colors duration-150 ease-out flex items-center justify-center"
               data-category-name={cat.name}
               data-active={active.active ? "" : undefined}
@@ -97,7 +97,7 @@ function initialActive(categoryName: string): {
     <div class="category-divider shrink-0 more-divider" aria-hidden="true"></div>
     <a
       href={url("/categories/")}
-      class="category-pill text-sm px-3 py-1.5 rounded-full shrink-0
+      class="category-pill focus-ring-inset text-sm px-3 py-1.5 rounded-full shrink-0
              transition-colors duration-150 ease-out flex items-center justify-center gap-1"
       data-category-name="__categories__"
       data-active={initialActive("__categories__").active ? "" : undefined}
@@ -112,9 +112,6 @@ function initialActive(categoryName: string): {
 <style>
   .category-bar .category-pill {
     border: none;
-  }
-  .category-bar .category-pill:focus-visible {
-    outline-offset: -2px;
   }
   .category-bar {
     margin-bottom: 1rem;

--- a/src/components/layout/DropdownMenu.astro
+++ b/src/components/layout/DropdownMenu.astro
@@ -43,7 +43,7 @@ const hasChildren = processedLink.children && processedLink.children.length > 0;
 						href={child.external ? child.url : url(child.url)}
 						target={child.external ? "_blank" : undefined}
 						isLast={index === (processedLink.children?.length || 0) - 1}
-						class="dropdown-item h-10"
+						class="dropdown-item focus-ring-inset h-10"
 					>
 						{child.icon && <Icon is:inline name={child.icon} class="text-[1.25rem] mr-3 navbar-icon" />}
 						<span>{child.name}</span>

--- a/src/components/layout/NavMenuPanel.astro
+++ b/src/components/layout/NavMenuPanel.astro
@@ -9,8 +9,8 @@ interface Props {
 
 const processedLinks = Astro.props.links;
 ---
-<div id="nav-menu-panel" class:list={["float-panel float-panel-closed transition-all fixed right-4 px-2 py-2 max-h-[80vh] overflow-y-auto"]}>
-    {processedLinks.map((link) => (
+<div id="nav-menu-panel" class:list={["float-panel float-panel-closed transition-all fixed right-4 px-2 py-2 max-h-[80vh] overflow-y-auto"]} data-floating-panel data-floating-panel-trigger="nav-menu-switch" inert aria-hidden="true">
+    {processedLinks.map((link, index) => (
         <div class="mobile-menu-item">
             {link.children && link.children.length > 0 ? (
                 /* 有子菜单的项目 */
@@ -20,6 +20,7 @@ const processedLinks = Astro.props.links;
                             hover:bg-(--btn-plain-bg-hover) active:bg-(--btn-plain-bg-active) transition"
                         data-mobile-dropdown-trigger
                         aria-expanded="false"
+                        aria-controls={`mobile-submenu-${index}`}
                     >
                         <div class="flex items-center transition text-black/75 dark:text-white/75 font-bold group-hover:text-(--primary) group-active:text-(--primary)">
 							{link.icon && <Icon is:inline name={link.icon} class="text-[1.1rem] mr-2" />}
@@ -29,7 +30,7 @@ const processedLinks = Astro.props.links;
                               class="transition text-[1.25rem] text-(--primary) mobile-dropdown-arrow duration-200"
                         />
                     </button>
-                    <div class="mobile-submenu" data-mobile-submenu>
+                    <div id={`mobile-submenu-${index}`} class="mobile-submenu" data-mobile-submenu inert aria-hidden="true">
                         {link.children.map((child) => (
                             <a href={child.external ? child.url : url(child.url)}
                                class="group flex justify-between items-center py-2 pl-6 pr-1 rounded-lg gap-8
@@ -103,19 +104,27 @@ const processedLinks = Astro.props.links;
                 // 关闭其他打开的下拉菜单
                 mobileDropdowns.forEach(otherDropdown => {
                     if (otherDropdown !== dropdown) {
-                        otherDropdown.setAttribute('data-expanded', 'false');
-                        const otherTrigger = otherDropdown.querySelector('[data-mobile-dropdown-trigger]');
-                        if (otherTrigger) {
-                            otherTrigger.setAttribute('aria-expanded', 'false');
-                        }
+                        setDropdownExpanded(otherDropdown, false);
                     }
                 });
 
                 // 切换当前下拉菜单
                 const newState = !isExpanded;
-                dropdown.setAttribute('data-expanded', newState.toString());
-                trigger.setAttribute('aria-expanded', newState.toString());
+                setDropdownExpanded(dropdown, newState);
             });
         });
     });
+
+    function setDropdownExpanded(dropdown: Element, isExpanded: boolean) {
+        dropdown.setAttribute('data-expanded', isExpanded.toString());
+
+        const trigger = dropdown.querySelector('[data-mobile-dropdown-trigger]');
+        trigger?.setAttribute('aria-expanded', isExpanded.toString());
+
+        const submenu = dropdown.querySelector('[data-mobile-submenu]');
+        if (submenu instanceof HTMLElement) {
+            submenu.inert = !isExpanded;
+            submenu.setAttribute('aria-hidden', (!isExpanded).toString());
+        }
+    }
 </script>

--- a/src/components/layout/Navbar.astro
+++ b/src/components/layout/Navbar.astro
@@ -185,14 +185,14 @@ const logoVariants = await Promise.all(
                     client:load
                 />
                 {musicPlayerConfig.showInNavbar && (
-                    <button aria-label={i18n(I18nKey.music)} class="btn-plain scale-animation rounded-lg h-9 w-9 md:h-11 md:w-11 active:scale-90" id="music-player-switch">
+                    <button aria-label={i18n(I18nKey.music)} aria-controls="music-nav-panel" aria-expanded="false" class="btn-plain scale-animation rounded-lg h-9 w-9 md:h-11 md:w-11 active:scale-90" id="music-player-switch">
                         <Icon is:inline name="material-symbols:music-note-rounded" class="text-[1.25rem]"></Icon>
                     </button>
                 )}
                 {backgroundWallpaper.playerEnable && backgroundWallpaper.mode !== "none" && (
                     <button
                         aria-label={i18n(I18nKey.videoPlay)}
-                        class="btn-plain scale-animation rounded-lg h-9 w-9 md:h-11 md:w-11 active:scale-90"
+						class="btn-plain scale-animation rounded-lg h-9 w-9 md:h-11 md:w-11 active:scale-90"
                         id="bg-player-toggle"
                         data-i18n-play={i18n(I18nKey.videoPlay)}
                         data-i18n-pause={i18n(I18nKey.videoPause)}
@@ -202,19 +202,19 @@ const logoVariants = await Promise.all(
                     </button>
                 )}
                 {hasDisplaySettings && (
-                        <button aria-label="Display Settings" class="btn-plain scale-animation rounded-lg h-9 w-9 md:h-11 md:w-11 active:scale-90" id="display-settings-switch">
+                        <button aria-label="Display Settings" aria-controls="display-setting" aria-expanded="false" class="btn-plain scale-animation rounded-lg h-9 w-9 md:h-11 md:w-11 active:scale-90" id="display-settings-switch">
                             <Icon is:inline name="material-symbols:palette-outline" class="text-[1.25rem]"></Icon>
                         </button>
                 )}
                 {/* @ts-ignore */}
                 <LightDarkSwitch client:load></LightDarkSwitch>
-                <button aria-label="Menu" name="Nav Menu" class="btn-plain scale-animation rounded-lg w-9 h-9 md:w-11 md:h-11 active:scale-90 lg:hidden!" id="nav-menu-switch">
+                <button aria-label="Menu" aria-controls="nav-menu-panel" aria-expanded="false" name="Nav Menu" class="btn-plain scale-animation rounded-lg w-9 h-9 md:w-11 md:h-11 active:scale-90 lg:hidden!" id="nav-menu-switch">
                     <Icon is:inline name="material-symbols:menu-rounded" class="text-[1.25rem]"></Icon>
                 </button>
             </div>
         </div>
         {musicPlayerConfig.showInNavbar && (
-            <div id="music-nav-panel" class="float-panel float-panel-closed absolute transition-all right-16 p-2 pt-4.5 w-80 z-50">
+            <div id="music-nav-panel" class="float-panel float-panel-closed absolute transition-all right-16 p-2 pt-4.5 w-80 z-50" data-floating-panel data-floating-panel-trigger="music-player-switch" inert aria-hidden="true">
                 <MusicPlayer />
             </div>
         )}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -768,6 +768,7 @@ const siteLang = lang.replace("_", "-");
     // MAIN_PANEL_OVERLAPS_BANNER_HEIGHT,
   } from "@/constants/constants";
   import { backgroundWallpaper, expressiveCodeConfig, siteConfig } from "@/config";
+  import { initializeFloatingPanels } from "@/utils/floating-panel-utils";
 
   /* Preload fonts */
   // (async function() {
@@ -815,6 +816,8 @@ function disableAnimation() {
 
   const bannerEnabled = !!document.getElementById("wallpaper-wrapper");
   const stickyNavbar = siteConfig.navbar.stickyNavbar ?? false;
+
+  initializeFloatingPanels();
 
   function setClickOutsideToClose(panel: string, ignores: string[]) {
       document.addEventListener("click", (event) => {
@@ -995,6 +998,7 @@ function disableAnimation() {
       }
     });
     window.swup.hooks.on("content:replace", () => {
+      initializeFloatingPanels();
       const isHome = pathsEqual(window.location.pathname, url("/"));
       const currentMode = document.documentElement.getAttribute("data-wallpaper-mode");
       const isMobileForBanner = window.innerWidth < 1024;

--- a/src/styles/display-settings.css
+++ b/src/styles/display-settings.css
@@ -72,10 +72,6 @@
 	transition: background-image 0.15s ease-in-out;
 }
 
-#display-setting .settings-tab:focus-visible {
-	outline-offset: -2px;
-}
-
 #display-setting .hue-slider-shell > input:focus-visible {
 	outline: none;
 }

--- a/src/styles/display-settings.css
+++ b/src/styles/display-settings.css
@@ -67,8 +67,22 @@
 }
 
 #display-setting #colorSlider {
+	border-radius: inherit;
 	background-image: var(--color-selection-bar);
 	transition: background-image 0.15s ease-in-out;
+}
+
+#display-setting .settings-tab:focus-visible {
+	outline-offset: -2px;
+}
+
+#display-setting .hue-slider-shell > input:focus-visible {
+	outline: none;
+}
+
+#display-setting .hue-slider-shell:has(> input:focus-visible) {
+	outline: 2px solid var(--primary);
+	outline-offset: 2px;
 }
 
 #display-setting #colorSlider::-webkit-slider-thumb {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -36,7 +36,8 @@
     z-index: -10;
     transition: all 0.15s ease-out;
   }
-  &:hover::before {
+  &:hover::before,
+  &:focus-visible::before {
     background-color: var(--btn-plain-bg-hover);
     scale: 1;
   }
@@ -51,6 +52,23 @@
 /* 确保平滑滚动 */
 html {
     scroll-behavior: smooth;
+}
+
+/* 全站键盘焦点基线；组件可以在更高的层中覆盖间距或形态。 */
+@layer components {
+    :where(
+        a[href],
+        button,
+        input,
+        select,
+        textarea,
+        summary,
+        [contenteditable="true"],
+        [tabindex]:not([tabindex="-1"])
+    ):focus-visible {
+        outline: 2px solid var(--primary);
+        outline-offset: 2px;
+    }
 }
 
 /* 页面顶部渐变高光效果 */
@@ -319,8 +337,14 @@ html {
     .btn-plain {
         @apply transition-colors duration-150 relative flex items-center justify-center bg-none
         text-black/75 hover:text-(--primary) dark:text-white/75 dark:hover:text-(--primary);
+        &:focus-visible {
+            color: var(--primary);
+        }
         &:not(.scale-animation) {
             @apply hover:bg-(--btn-plain-bg-hover) active:bg-(--btn-plain-bg-active)
+        }
+        &:not(.scale-animation):focus-visible {
+            background-color: var(--btn-plain-bg-hover);
         }
         &.scale-animation {
             @apply expand-animation;
@@ -438,12 +462,9 @@ html {
         @apply pointer-events-auto;
     }
 
-    .dropdown-item:focus {
-        @apply outline-hidden;
-    }
-
-    .mobile-dropdown button:focus {
-        @apply outline-hidden;
+    .dropdown-item:focus-visible {
+        outline: 2px solid var(--primary);
+        outline-offset: -2px;
     }
 
     .meta-icon {
@@ -599,4 +620,3 @@ html {
 .pagination-info {
   @apply text-sm text-(--text-secondary) text-center mb-2;
 }
-

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -69,6 +69,11 @@ html {
         outline: 2px solid var(--primary);
         outline-offset: 2px;
     }
+
+    /* 用于外侧焦点环会被溢出隐藏容器裁切的交互元素。 */
+    .focus-ring-inset:focus-visible {
+        outline-offset: -2px;
+    }
 }
 
 /* 页面顶部渐变高光效果 */
@@ -460,11 +465,6 @@ html {
     /* 无障碍支持 */
     .dropdown-container:focus-within .dropdown-menu {
         @apply pointer-events-auto;
-    }
-
-    .dropdown-item:focus-visible {
-        outline: 2px solid var(--primary);
-        outline-offset: -2px;
     }
 
     .meta-icon {

--- a/src/utils/floating-panel-utils.ts
+++ b/src/utils/floating-panel-utils.ts
@@ -1,0 +1,115 @@
+const CLOSED_CLASS = "float-panel-closed";
+const PANEL_SELECTOR = "[data-floating-panel]";
+const FOCUS_RETURN_ATTRIBUTE = "data-floating-panel-focus-return";
+export const FLOATING_PANEL_CLOSE_EVENT = "floating-panel:close";
+
+const observedPanels = new WeakSet<HTMLElement>();
+const panelOpenStates = new WeakMap<HTMLElement, boolean>();
+let escapeListenerAttached = false;
+
+function getPanelTriggers(panel: HTMLElement): HTMLElement[] {
+	const triggerIds = panel.dataset.floatingPanelTrigger
+		?.split(/\s+/)
+		.filter(Boolean);
+
+	if (!triggerIds) return [];
+
+	return triggerIds
+		.map((id) => document.getElementById(id))
+		.filter((trigger): trigger is HTMLElement => trigger !== null);
+}
+
+function isVisible(element: HTMLElement): boolean {
+	const style = window.getComputedStyle(element);
+	return (
+		style.display !== "none" &&
+		style.visibility !== "hidden" &&
+		element.getClientRects().length > 0
+	);
+}
+
+function syncFloatingPanelState(panel: HTMLElement): void {
+	const isOpen = !panel.classList.contains(CLOSED_CLASS);
+	const wasOpen = panelOpenStates.get(panel);
+
+	panel.inert = !isOpen;
+	panel.setAttribute("aria-hidden", String(!isOpen));
+
+	for (const trigger of getPanelTriggers(panel)) {
+		if (panel.id) trigger.setAttribute("aria-controls", panel.id);
+		if (!trigger.hasAttribute("data-floating-panel-no-expanded")) {
+			trigger.setAttribute("aria-expanded", String(isOpen));
+		}
+	}
+
+	panelOpenStates.set(panel, isOpen);
+	if (wasOpen === true && !isOpen) {
+		panel.dispatchEvent(new Event(FLOATING_PANEL_CLOSE_EVENT));
+	}
+}
+
+function setFloatingPanelOpen(panel: HTMLElement, isOpen: boolean): void {
+	panel.classList.toggle(CLOSED_CLASS, !isOpen);
+	syncFloatingPanelState(panel);
+}
+
+function handleEscape(event: KeyboardEvent): void {
+	if (event.key !== "Escape") return;
+
+	const target = event.target instanceof Node ? event.target : null;
+	const openPanels = Array.from(
+		document.querySelectorAll<HTMLElement>(PANEL_SELECTOR),
+	).filter((panel) => !panel.classList.contains(CLOSED_CLASS));
+
+	const activePanel = openPanels.find((panel) => {
+		if (!target) return false;
+		return (
+			panel.contains(target) ||
+			getPanelTriggers(panel).some((trigger) => trigger.contains(target))
+		);
+	});
+
+	if (!activePanel) return;
+
+	event.preventDefault();
+	setFloatingPanelOpen(activePanel, false);
+
+	const triggers = getPanelTriggers(activePanel);
+	const trigger = triggers.find(isVisible) ?? triggers[0];
+	if (!trigger) return;
+
+	try {
+		trigger.setAttribute(FOCUS_RETURN_ATTRIBUTE, "");
+		trigger.focus();
+	} finally {
+		trigger.removeAttribute(FOCUS_RETURN_ATTRIBUTE);
+	}
+}
+
+export function initializeFloatingPanels(root: ParentNode = document): void {
+	const panels = Array.from(root.querySelectorAll<HTMLElement>(PANEL_SELECTOR));
+
+	if (root instanceof HTMLElement && root.matches(PANEL_SELECTOR)) {
+		panels.unshift(root);
+	}
+
+	for (const panel of panels) {
+		syncFloatingPanelState(panel);
+
+		if (observedPanels.has(panel)) continue;
+
+		const observer = new MutationObserver(() => {
+			syncFloatingPanelState(panel);
+		});
+		observer.observe(panel, {
+			attributes: true,
+			attributeFilter: ["class"],
+		});
+		observedPanels.add(panel);
+	}
+
+	if (!escapeListenerAttached) {
+		document.addEventListener("keydown", handleEscape);
+		escapeListenerAttached = true;
+	}
+}

--- a/src/utils/floating-panel-utils.ts
+++ b/src/utils/floating-panel-utils.ts
@@ -3,7 +3,7 @@ const PANEL_SELECTOR = "[data-floating-panel]";
 const FOCUS_RETURN_ATTRIBUTE = "data-floating-panel-focus-return";
 export const FLOATING_PANEL_CLOSE_EVENT = "floating-panel:close";
 
-const observedPanels = new WeakSet<HTMLElement>();
+const panelObservers = new Map<HTMLElement, MutationObserver>();
 const panelOpenStates = new WeakMap<HTMLElement, boolean>();
 let escapeListenerAttached = false;
 
@@ -86,7 +86,19 @@ function handleEscape(event: KeyboardEvent): void {
 	}
 }
 
+function disconnectRemovedPanelObservers(): void {
+	for (const [panel, observer] of panelObservers) {
+		if (panel.isConnected) continue;
+
+		observer.disconnect();
+		panelObservers.delete(panel);
+		panelOpenStates.delete(panel);
+	}
+}
+
 export function initializeFloatingPanels(root: ParentNode = document): void {
+	disconnectRemovedPanelObservers();
+
 	const panels = Array.from(root.querySelectorAll<HTMLElement>(PANEL_SELECTOR));
 
 	if (root instanceof HTMLElement && root.matches(PANEL_SELECTOR)) {
@@ -96,7 +108,7 @@ export function initializeFloatingPanels(root: ParentNode = document): void {
 	for (const panel of panels) {
 		syncFloatingPanelState(panel);
 
-		if (observedPanels.has(panel)) continue;
+		if (panelObservers.has(panel)) continue;
 
 		const observer = new MutationObserver(() => {
 			syncFloatingPanelState(panel);
@@ -105,7 +117,7 @@ export function initializeFloatingPanels(root: ParentNode = document): void {
 			attributes: true,
 			attributeFilter: ["class"],
 		});
-		observedPanels.add(panel);
+		panelObservers.set(panel, observer);
 	}
 
 	if (!escapeListenerAttached) {


### PR DESCRIPTION
# PR

## Type of change / 变更类型

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist / 检查清单

- [x] I have read the CONTRIBUTING document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue / 关联 Issue

Fixes #538

## Changes / 变更内容

### 中文

#### 浮层状态与键盘行为

- 新增共享的浮层状态同步逻辑，根据 `float-panel-closed` 状态统一维护 `inert`、`aria-hidden`、`aria-controls` 和 `aria-expanded`。
- 将搜索、显示设置、深浅色模式、音乐和移动端导航面板接入同一套状态逻辑。
- 关闭的面板及折叠的移动端子菜单不再进入顺序焦点导航。
- 支持使用 `Escape` 关闭当前活动面板，并将焦点返回当前布局中可见的触发控件。
- 在 Swup 内容替换后重新同步浮层状态，并断开已从文档移除的浮层观察器。

#### 焦点反馈和交互结构

- 为常见交互元素提供统一的主题色 `:focus-visible` 基线。
- 导航栏主要按钮在键盘聚焦时采用与悬停相近的背景和文字反馈。
- 使用共享的 `focus-ring-inset` 工具类处理可能被容器裁切的焦点环，保留普通元素外扩焦点环的默认行为。
- 调整导航子菜单、分类链接、显示设置标签和主题色滑块的焦点环位置与圆角。
- 将不可见的显示设置重置按钮设为禁用并从无障碍树中隐藏。
- 将侧边栏分类组件中的嵌套 `<a><button>` 改为单一链接，消除重复焦点停靠点并保留原有视觉行为。

#### 搜索生命周期

- 面板关闭时取消尚未执行的防抖搜索。
- 使用请求序号忽略已经失效的异步搜索结果。
- 防止通过 `Escape` 或点击外部关闭的搜索面板被旧结果重新打开。
- 在组件卸载时移除事件监听器并取消待处理搜索。

### English

#### Floating-panel state and keyboard behavior

- Add shared floating-panel state synchronization based on `float-panel-closed`, maintaining `inert`, `aria-hidden`, `aria-controls`, and `aria-expanded`.
- Apply the same state handling to search, display settings, theme mode, music, and mobile navigation panels.
- Exclude closed panels and collapsed mobile submenus from sequential focus navigation.
- Support closing the active panel with `Escape` and returning focus to the visible trigger for the current layout.
- Resynchronize panel state after Swup content replacement and disconnect observers whose panels have left the document.

#### Focus feedback and interactive markup

- Add a theme-colored `:focus-visible` baseline for common interactive elements.
- Give primary navigation buttons keyboard-focus feedback consistent with their hover treatment.
- Use a shared `focus-ring-inset` utility for focus rings that could be clipped, while preserving the default outward ring for ordinary elements.
- Adjust focus-ring position and radius for navigation submenu items, category links, display-setting tabs, and the hue slider.
- Disable invisible display-setting reset buttons and hide them from the accessibility tree.
- Replace the nested `<a><button>` sidebar category structure with one link, removing duplicate focus stops while preserving its visual behavior.

#### Search lifecycle

- Cancel pending debounced searches when the panel closes.
- Use request identifiers to ignore stale asynchronous results.
- Prevent results from reopening a search panel dismissed by `Escape` or an outside click.
- Remove listeners and cancel pending work when the component is unmounted.

## Review follow-up / 评审意见处理

- `MutationObserver` instances are now tracked per panel. Each re-initialization disconnects and removes observers for detached panels and clears their cached open state.
- Component-local focus-offset overrides were replaced with the shared `focus-ring-inset` class. The inset offset remains limited to controls whose outer ring would otherwise be clipped.
- Addressed in commit `a96a8a36`.

## How To Test / 测试方法

### Automated checks / 自动检查

```text
pnpm check
pnpm type-check
pnpm exec biome ci ./src --reporter=github
pnpm build
git diff --check
```

Results / 结果：

- `pnpm check`: 0 errors, 0 warnings, 0 hints
- `pnpm type-check`: passed
- Biome CI: passed
- Production build: passed
- Whitespace validation: passed
- Netlify deploy preview: passed
- Sourcery review for the latest commit: passed with no new findings

### Browser and keyboard checks / 浏览器与键盘检查

1. On the home, archive, categories, and post pages, press `Tab` through the header with all panels closed. Descendants of closed panels should be skipped.
   在首页、归档、分类和文章页面保持所有面板关闭并使用 `Tab` 浏览标题栏；已关闭面板中的控件应被跳过。
2. Open the theme, display settings, search, music, and mobile navigation panels. Their controls should enter the focus order only while open; `Escape` should close the active panel and restore focus to its visible trigger.
   分别打开各个浮层；只有打开的浮层控件才应进入焦点顺序，按下 `Escape` 后应关闭并将焦点返回可见触发控件。
3. In mobile navigation, collapsed submenu links should be skipped and become reachable after expansion.
   移动端折叠子菜单中的链接应被跳过，展开后应可访问。
4. Focus rings for display-setting tabs, the hue slider, navigation submenu items, and category links should follow their shapes without clipping.
   显示设置标签、色相滑块、导航子菜单和分类链接的焦点环应匹配控件形状且不被裁切。
5. Each sidebar category should create one focus stop, and pressing `Enter` on category or post-title links should navigate normally.
   每个侧边栏分类应只有一个焦点停靠点，分类及文章标题链接按下 `Enter` 后应正常跳转。
6. Dismiss a search before its debounce completes. Stale results should not reopen the panel, while a subsequent query should work normally.
   在搜索防抖完成前关闭面板；旧结果不应重新打开面板，后续查询仍应正常工作。

Additional browser regression / 附加浏览器回归：连续执行 3 轮首页与文章页的 Swup 往返导航后，5 个浮层节点的数量和标识保持稳定，控制台无错误。

## Preview / 预览

- Netlify: https://deploy-preview-539--demo-firefly.netlify.app
- Static screenshots are not included because the key changes concern keyboard focus order and state transitions; the deploy preview and steps above provide the reproducible verification path.
- 本次修改主要涉及键盘焦点顺序与状态切换，因此未添加静态截图；可通过部署预览和上述步骤复现验证。

## Additional Notes / 补充说明

### 中文

- 没有新增依赖、配置项或内容变更。
- 打开的浮层仍使用正常文档焦点顺序，本 PR 没有实现模态式焦点限制。
- 本 PR 不处理客户端页面跳转后的初始焦点策略，也不重新设计音乐播放器内部控件的焦点环。
- 当前生产构建仍会报告既有的 Vite 大分块警告和 Pagefind `/dynamic/comments/` 缺少 `<html>` 的提示；未修改的 `fc43555` 基线构建会产生相同输出，本 PR 没有新增构建警告。

### English

- No dependencies, configuration options, or content changes are introduced.
- Open panels remain in the normal document focus order; this PR does not add modal focus trapping.
- This PR does not change initial focus after client-side navigation or redesign the focus-ring geometry of internal music-player controls.
- The production build retains the existing Vite large-chunk warning and Pagefind notice for `/dynamic/comments/` lacking an `<html>` element. An unmodified `fc43555` baseline build produces the same output, so this PR introduces no new build warnings.
