### PR TITLE
移除 vercel.json 中的 cleanUrls: true

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -34,6 +34,5 @@
         }
       ]
     }
-  ],
-  "cleanUrls": true
+  ]
 }


### PR DESCRIPTION
cleanUrls: true 与 Astro 的 trailingSlash: "always" 冲突：vercel build 生成 .vercel/output/config.json 时，CLI 会把所有 HTML 文件改写为无扩展名路径（about/index.html → about/index），并生成 308 重定向规则。结果：
/about/ 目录解析找不到 about/index.html（已被改名）→ 404；
/about/index 又被 308 规则切回 /about → 404。

## Summary by Sourcery

Build:
- 从 `vercel.json` 中删除 `cleanUrls` 选项，以便 Vercel 不再将 HTML 路径重写为无扩展名的 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Delete the cleanUrls option from vercel.json so Vercel no longer rewrites HTML paths to extensionless URLs.

</details>