### PR TITLE
fix: 恢复音乐播放器配置从 local 为 meting

### DIFF
--- a/src/config/musicConfig.ts
+++ b/src/config/musicConfig.ts
@@ -9,7 +9,7 @@ export const musicPlayerConfig: MusicPlayerConfig = {
 	showInSidebar: true,
 
 	// 使用方式："meting" 使用 Meting API，"local" 使用本地音乐列表
-	mode: "local",
+	mode: "meting",
 
 	// 默认音量 (0-1)
 	volume: 0.7,


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

<!-- Please link to the issue that this pull request addresses. e.g. #123 -->

## Changes

- 将 `musicPlayerConfig` 中的 `mode` 从 `"local"` 修正为 `"meting"`
- 恢复使用 Meting API 获取在线歌单数据

## How To Test

1. 启动项目，进入页面
2. 检查音乐播放器是否正常加载歌单
3. 验证歌曲是否可以正常播放

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->

## Additional Notes

<!-- 原配置中 mode 被误设为 local，现修正为 meting 以使用正确的 API 数据源。 -->

## Summary by Sourcery

Bug Fixes:
- 将音乐播放器的配置模式从“local”更正为“meting”，以便在线播放列表能够正确加载并播放。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the music player configuration mode from "local" to "meting" so online playlists load and play correctly.

</details>