### PR TITLE
修复 quarantine-bad-posts 脚本的多处缺陷

### DIFF
--- a/scripts/quarantine-bad-posts.mjs
+++ b/scripts/quarantine-bad-posts.mjs
@@ -18,23 +18,46 @@ if (!fs.existsSync(QUARANTINE_DIR)) {
 function walk(dir) {
 	return fs.readdirSync(dir).flatMap((f) => {
 		const p = path.join(dir, f);
-		return fs.statSync(p).isDirectory() ? walk(p) : f === "index.md" ? [p] : [];
+		if (fs.statSync(p).isDirectory()) return walk(p);
+		// 收录所有 .md / .mdx 文章（含顶层文件和子目录里的 index.md）
+		return /\.mdx?$/.test(f) ? [p] : [];
 	});
 }
 
 function hasMissingImage(file) {
 	const raw = fs.readFileSync(file, "utf8");
-	const { data, content } = matter(raw);
+	let data, content;
+	try {
+		({ data, content } = matter(raw));
+	} catch (err) {
+		// frontmatter 解析失败（如重复键 / 缩进错误）：视为坏文章，隔离并告警
+		console.warn(`⚠️ frontmatter 解析失败，将隔离: ${file}\n   ${err.message}`);
+		return true;
+	}
 
 	const images = new Set();
 
 	// frontmatter 里的 image
-	if (typeof data.image === "string") {
+	// "api" 是主题内置随机封面图，不是真实路径，跳过；
+	// http(s) 外链也不检查（与正文图片的处理一致）
+	if (
+		typeof data.image === "string" &&
+		data.image !== "api" &&
+		!/^https?:\/\//.test(data.image)
+	) {
 		images.add(data.image);
 	}
 
+	// 先把代码块/行内代码剥掉，避免把示例代码里的 ![...] 当真实引用
+	const codeStripped = content
+		.replace(/^ {4,}.*$/gm, "") // 缩进代码块（4+ 空格）
+		.replace(/^\t.*$/gm, "") // tab 缩进代码块
+		.replace(/```[\s\S]*?```/g, "") // 围栏代码块（反引号）
+		.replace(/~~~[\s\S]*?~~~/g, "") // 围栏代码块（波浪号）
+		.replace(/`[^`\n]+`/g, ""); // 行内代码
+
 	// markdown 里的 ![alt](path)
-	const mdImages = [...content.matchAll(/!\[.*?\]\((.+?)\)/g)]
+	const mdImages = [...codeStripped.matchAll(/!\[.*?\]\((.+?)\)/g)]
 		.map((m) => m[1])
 		.filter((p) => !p.startsWith("http"));
 
@@ -55,7 +78,8 @@ function main() {
 
 	for (const file of files) {
 		if (hasMissingImage(file)) {
-			const target = file.replace(POSTS_DIR, QUARANTINE_DIR);
+			// 用 path.relative + path.join 拼目标路径，避免 Windows 下正反斜杠不匹配导致 replace 失效、文件没真挪走
+			const target = path.resolve(QUARANTINE_DIR, path.relative(POSTS_DIR, file));
 			fs.mkdirSync(path.dirname(target), { recursive: true });
 			fs.renameSync(file, target);
 			console.log(`🚫 Quarantined: ${file}`);

--- a/scripts/quarantine-bad-posts.mjs
+++ b/scripts/quarantine-bad-posts.mjs
@@ -15,11 +15,43 @@ if (!fs.existsSync(QUARANTINE_DIR)) {
 	fs.mkdirSync(QUARANTINE_DIR, { recursive: true });
 }
 
+// 图片是不是外链：http(s) / 协议相对的 //xxx / 其它协议都算。
+// 前言和正文共用这一个判断，免得两边规则又对不齐。
+function isExternalUrl(url) {
+	return /^(https?:\/\/|\/\/|[\w+.-]+:)/i.test(url);
+}
+
+// 先把代码剥掉，否则示例代码里的 ![...] 会被当成真引用。
+// 围栏块（``` / ~~~）和行内代码（反引号）直接删；
+// 缩进块只在“前面是空行”的连续缩进行才算代码，免得把列表嵌套子项也误删。
+function stripCode(md) {
+	let out = md
+		.replace(/```[\s\S]*?```/g, "")
+		.replace(/~~~[\s\S]*?~~~/g, "")
+		.replace(/`[^`\n]+`/g, "");
+
+	const lines = out.split("\n");
+	const kept = [];
+	let i = 0;
+	while (i < lines.length) {
+		const line = lines[i];
+		const indented = /^ {4,}|\t/.test(line);
+		const prevBlank = i === 0 || lines[i - 1].trim() === "";
+		if (indented && prevBlank) {
+			while (i < lines.length && /^ {4,}|\t/.test(lines[i])) i++;
+			continue;
+		}
+		kept.push(line);
+		i++;
+	}
+	return kept.join("\n");
+}
+
 function walk(dir) {
 	return fs.readdirSync(dir).flatMap((f) => {
 		const p = path.join(dir, f);
 		if (fs.statSync(p).isDirectory()) return walk(p);
-		// 收录所有 .md / .mdx 文章（含顶层文件和子目录里的 index.md）
+		// 收全部 .md / .mdx（顶层文件 + 子目录里的 index.md 都算）
 		return /\.mdx?$/.test(f) ? [p] : [];
 	});
 }
@@ -30,36 +62,23 @@ function hasMissingImage(file) {
 	try {
 		({ data, content } = matter(raw));
 	} catch (err) {
-		// frontmatter 解析失败（如重复键 / 缩进错误）：视为坏文章，隔离并告警
+		// 某篇 frontmatter 写崩了（比如重复键）就隔离并告警，别让整轮跟着死
 		console.warn(`⚠️ frontmatter 解析失败，将隔离: ${file}\n   ${err.message}`);
 		return true;
 	}
 
 	const images = new Set();
 
-	// frontmatter 里的 image
-	// "api" 是主题内置随机封面图，不是真实路径，跳过；
-	// http(s) 外链也不检查（与正文图片的处理一致）
-	if (
-		typeof data.image === "string" &&
-		data.image !== "api" &&
-		!/^https?:\/\//.test(data.image)
-	) {
+	// "api" 是主题内置的随机封面，不是真路径，跳过；外链也跳过
+	if (typeof data.image === "string" && data.image !== "api" && !isExternalUrl(data.image)) {
 		images.add(data.image);
 	}
 
-	// 先把代码块/行内代码剥掉，避免把示例代码里的 ![...] 当真实引用
-	const codeStripped = content
-		.replace(/^ {4,}.*$/gm, "") // 缩进代码块（4+ 空格）
-		.replace(/^\t.*$/gm, "") // tab 缩进代码块
-		.replace(/```[\s\S]*?```/g, "") // 围栏代码块（反引号）
-		.replace(/~~~[\s\S]*?~~~/g, "") // 围栏代码块（波浪号）
-		.replace(/`[^`\n]+`/g, ""); // 行内代码
-
-	// markdown 里的 ![alt](path)
+	// 正文里的 ![alt](path)：剥完代码再提，URL 同样用 isExternalUrl 判内外
+	const codeStripped = stripCode(content);
 	const mdImages = [...codeStripped.matchAll(/!\[.*?\]\((.+?)\)/g)]
 		.map((m) => m[1])
-		.filter((p) => !p.startsWith("http"));
+		.filter((p) => !isExternalUrl(p));
 
 	for (const p of mdImages) images.add(p);
 
@@ -78,7 +97,7 @@ function main() {
 
 	for (const file of files) {
 		if (hasMissingImage(file)) {
-			// 用 path.relative + path.join 拼目标路径，避免 Windows 下正反斜杠不匹配导致 replace 失效、文件没真挪走
+			// Windows 正反斜杠不一致，直接 replace 会失效、文件其实没挪走；用 relative + join 
 			const target = path.resolve(QUARANTINE_DIR, path.relative(POSTS_DIR, file));
 			fs.mkdirSync(path.dirname(target), { recursive: true });
 			fs.renameSync(file, target);


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

无（本次修改为仓库审计中发现的既有缺陷，未关联现有 issue；如需可另开 issue 并引用）。

## Changes

`scripts/quarantine-bad-posts.mjs` 原版存在多处逻辑与健壮性问题，在 Windows 上实际无法正常工作。本次修复：

- **扫描不全**：`walk()` 原仅收集 `index.md`，漏掉顶层 `.md` 文章与所有 `.mdx` 文章 → 改为收录全部 `.mdx?` 文件。
- **误判随机图**：未识别 `image: "api"` 主题内置随机图哨兵 → 跳过。
- **误判外链**：frontmatter 的 `image` 未过滤 `http(s)` 外链 → 跳过（与正文图片处理一致）。
- **误判示例代码**：正文代码块 / 行内代码里的 `![...]` 被当成真实图片引用 → 扫描前先剥离代码。
- **无容错**：单篇 frontmatter 解析失败（如重复键）会让整轮进程崩溃 → 改为隔离该篇并告警、继续处理其余文章。
- **Windows 下文件未真正移动**：`file.replace(POSTS_DIR, QUARANTINE_DIR)` 在 Windows 上因正反斜杠不匹配而 `replace` 失效，`renameSync` 退化为空操作（重命名成自己），脚本只打印假 `🚫 Quarantined` 日志却从未移动文件 → 改用 `path.resolve(QUARANTINE_DIR, path.relative(POSTS_DIR, file))` 正确拼接目标路径。


## How To Test

1. 在仓库根目录直接运行

   ```bash
   node scripts/quarantine-bad-posts.mjs
   ```

3. 验证隔离逻辑：可临时放入若干测试文章（含 `image: /不存在.png`、正文 `![x](/不存在.png)`、`.mdx`、顶层 `.md`、`image: "api"`、`image: https://...`、代码块内假图、frontmatter 重复键等），预期仅「真坏图 / 解析失败」的文章被移入 `src/content/_quarantine`，其余（api 、http(s) 外链、真实存在的图片、代码块假图）保留。
4. 我本地用 15 篇覆盖各类参数与边界的测试文章实跑，结果：隔离 8 篇、保留 7 篇，与预期一致。


## Screenshots (if applicable)

无

## Additional Notes

- 该脚本为独立维护工具，未接入 `package.json` scripts 与 CI，不影响现有构建/发布流程。
- 注意：修复前在 Windows 上脚本「看似运行成功」但实际未移动任何文件（假日志），本次修复后才会真正把坏文章移出 `posts` 集合；若此前曾运行过，请确认 `src/content/posts` 下没有被错误遗留的 `_quarantine` 目录。

## Summary by Sourcery

改进 `quarantine-bad-posts` 维护脚本，以在各个平台上正确识别并隔离包含无效图片的帖子。

Bug 修复：
- 确保扫描所有 Markdown 和 MDX 帖子文件，而不是只扫描 `index.md` 文件。
- 通过跳过主题的随机封面图和 frontmatter 中的外部图片 URL，避免误报。
- 在检查帖子时，不再将代码块或行内代码中的类图片语法当作真实图片引用。
- 优雅地处理 frontmatter 解析失败的情况，只隔离有问题的帖子并继续处理其他帖子。
- 修复 Windows 路径处理问题，确保被隔离的帖子会实际移动到隔离目录，而不是留在原位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the quarantine-bad-posts maintenance script to correctly identify and isolate posts with invalid images across platforms.

Bug Fixes:
- Ensure all markdown and MDX post files are scanned instead of only index.md files.
- Prevent false positives by skipping theme random cover images and external image URLs in frontmatter.
- Avoid treating image-like syntax inside code blocks or inline code as real image references when checking posts.
- Handle frontmatter parsing failures gracefully by quarantining only the problematic post and continuing processing.
- Fix Windows path handling so quarantined posts are actually moved into the quarantine directory instead of being left in place.

</details>