### PR TITLE
fix: 修复 Star History 图表无法显示的问题

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -317,7 +317,7 @@ Thanks to the following contributors for their contributions to the original pro
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=CuteLeaf/Firefly&type=Date)](https://star-history.com/#CuteLeaf/Firefly&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CuteLeaf/Firefly&type=Date)](https://star-history.dera.page/#CuteLeaf/Firefly&Date)
 
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ location: China # 位置
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=CuteLeaf/Firefly&type=Date)](https://star-history.com/#CuteLeaf/Firefly&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CuteLeaf/Firefly&type=Date)](https://star-history.dera.page/#CuteLeaf/Firefly&Date)
 
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -317,7 +317,7 @@ MIT ライセンスに基づき、コードの自由な使用、変更、配布�
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=CuteLeaf/Firefly&type=Date)](https://star-history.com/#CuteLeaf/Firefly&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CuteLeaf/Firefly&type=Date)](https://star-history.dera.page/#CuteLeaf/Firefly&Date)
 
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -319,7 +319,7 @@ location: China # 位置
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=CuteLeaf/Firefly&type=Date)](https://star-history.com/#CuteLeaf/Firefly&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CuteLeaf/Firefly&type=Date)](https://star-history.dera.page/#CuteLeaf/Firefly&Date)
 
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firefly",
   "type": "module",
-  "version": "6.15.9",
+  "version": "6.15.10",
   "engines": {
     "node": ">=22.23.0"
   },

--- a/src/components/pages/dynamic/DynamicGallery.astro
+++ b/src/components/pages/dynamic/DynamicGallery.astro
@@ -35,6 +35,7 @@ const { sourceId } = Astro.props;
 				<Icon is:inline name="material-symbols:zoom-in-rounded" />
 				<span>{i18n(I18nKey.dynamicViewOriginal)}</span>
 			</button>
+			<span class="dynamic-gallery-counter" data-gallery-counter aria-live="polite"></span>
 		</div>
 
 		<div class="dynamic-gallery-stage">

--- a/src/components/pages/dynamic/dynamic-gallery.ts
+++ b/src/components/pages/dynamic/dynamic-gallery.ts
@@ -38,12 +38,7 @@ export function registerDynamicGallery(): void {
 			const grid = this.querySelector<HTMLElement>("[data-gallery-grid]");
 			if (!grid) return;
 			grid.dataset.count = String(Math.min(this.images.length, 6));
-			grid.dataset.layout =
-				this.images.length === 1
-					? "single"
-					: this.images.length <= 4
-						? "two"
-						: "three";
+			grid.dataset.layout = this.images.length === 1 ? "single" : "grid";
 			this.images.slice(0, 6).forEach(({ element, alt }, index) => {
 				const button = document.createElement("button");
 				button.type = "button";
@@ -131,7 +126,6 @@ export function registerDynamicGallery(): void {
 						this.images.map((image) => ({
 							src: image.src,
 							type: "image",
-							caption: image.alt,
 						})),
 						{
 							startIndex: this.activeIndex,
@@ -164,7 +158,6 @@ export function registerDynamicGallery(): void {
 				this.images.map((image) => ({
 					src: image.src,
 					type: "image",
-					caption: image.alt,
 				})),
 				{ startIndex: index },
 			);
@@ -172,20 +165,15 @@ export function registerDynamicGallery(): void {
 
 		private select(index: number) {
 			this.activeIndex = (index + this.images.length) % this.images.length;
+			const counter = this.querySelector<HTMLElement>("[data-gallery-counter]");
+			if (counter)
+				counter.textContent = `${this.activeIndex + 1} / ${this.images.length}`;
 			const image = this.images[this.activeIndex];
 			const main = this.querySelector<HTMLImageElement>("[data-gallery-main]");
 			if (!main) return;
 			main.src = image.src;
 			main.alt = image.alt;
 			main.dataset.galleryIndex = String(this.activeIndex);
-			const updateAspect = () => {
-				if (main.naturalWidth === 0 || main.naturalHeight === 0) return;
-				const stage = this.querySelector<HTMLElement>(".dynamic-gallery-stage");
-				if (stage)
-					stage.style.aspectRatio = `${main.naturalWidth} / ${main.naturalHeight}`;
-			};
-			if (main.complete && main.naturalWidth > 0) updateAspect();
-			else main.addEventListener("load", updateAspect, { once: true });
 			this.querySelector<HTMLElement>("[data-gallery-lightbox]")?.setAttribute(
 				"data-src",
 				image.src,

--- a/src/styles/dynamic.css
+++ b/src/styles/dynamic.css
@@ -366,7 +366,7 @@ dynamic-feed {
 	display: block;
 	box-sizing: border-box;
 	min-width: 0;
-	width: min(calc(100% - 3.75rem), 48rem);
+	width: min(calc(100% - 3.75rem), 56rem);
 	max-width: 100%;
 	margin: 0.875rem 0 0 3.75rem;
 }
@@ -381,14 +381,33 @@ dynamic-feed {
 	display: grid;
 	box-sizing: border-box;
 	min-width: 0;
-	width: min(100%, 34rem);
+	width: min(100%, 48rem);
 	max-width: 100%;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
 	gap: 0.25rem;
 }
 
-.dynamic-gallery-grid[data-layout="three"] {
+.dynamic-gallery-grid[data-count="4"] {
+	width: min(100%, 32rem);
+}
+
+.dynamic-gallery-grid[data-count="5"],
+.dynamic-gallery-grid[data-count="6"] {
 	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.dynamic-gallery-grid[data-count="3"] {
+	grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+}
+
+.dynamic-gallery-grid[data-count="5"] {
+	grid-template-columns: minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.dynamic-gallery-grid[data-count="3"] .dynamic-gallery-grid-item:first-child,
+.dynamic-gallery-grid[data-count="5"] .dynamic-gallery-grid-item:first-child {
+	grid-row: span 2;
+	aspect-ratio: auto;
 }
 
 .dynamic-gallery-grid-item {
@@ -415,6 +434,7 @@ dynamic-feed {
 	width: fit-content;
 	max-width: 100%;
 	aspect-ratio: auto;
+	background: transparent;
 }
 
 .dynamic-gallery-grid-item img {
@@ -423,11 +443,12 @@ dynamic-feed {
 	height: 100%;
 	margin: 0;
 	object-fit: cover;
+	border-radius: inherit;
 }
 
 .dynamic-gallery-grid[data-layout="single"] img {
 	width: auto;
-	max-width: 100%;
+	max-width: min(100%, 36rem);
 	max-height: min(32rem, 65vh);
 	height: auto;
 	object-fit: contain;
@@ -476,26 +497,42 @@ dynamic-feed {
 	font-size: 1.15rem;
 }
 
+.dynamic-gallery-counter {
+	margin-left: auto;
+	display: inline-flex;
+	align-items: center;
+	min-height: 1.5rem;
+	padding-inline: 0.55rem;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--primary) 12%, transparent);
+	color: var(--primary);
+	font-size: 0.75rem;
+	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+	white-space: nowrap;
+}
+
 .dynamic-gallery-stage {
 	position: relative;
-	display: grid;
+	display: block;
+	box-sizing: border-box;
 	min-width: 0;
 	width: 100%;
 	max-width: 100%;
-	aspect-ratio: 16 / 9;
-	place-items: center;
-	overflow: hidden;
-	background: rgb(0 0 0 / 88%);
+	padding-inline: 4rem;
 }
 
 .dynamic-gallery-main-image {
 	display: block;
 	min-width: 0;
-	width: 100%;
+	width: auto;
 	max-width: 100%;
-	height: 100%;
-	margin: 0;
+	height: auto;
+	max-height: min(32rem, 65vh);
+	margin: 0 auto;
 	object-fit: contain;
+	background: rgb(0 0 0 / 88%);
+	border-radius: calc(var(--radius-large) - 0.25rem);
 }
 
 .dynamic-gallery-nav {
@@ -774,10 +811,18 @@ body.wallpaper-transparent .dynamic-year-select select option {
 		max-height: min(28rem, 65vh);
 	}
 
+	.dynamic-gallery-stage .dynamic-gallery-main-image {
+		max-height: min(28rem, 65vh);
+	}
+
 	.dynamic-gallery-nav {
 		width: 2.25rem;
 		height: 2.25rem;
 		font-size: 1.45rem;
+	}
+
+	.dynamic-gallery-stage {
+		padding-inline: 3rem;
 	}
 
 	.dynamic-gallery-prev {


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub 星标接口限制而失效，无法正常显示。本 PR 将 README.md、README.en.md 以及 docs 下的各语言版本文档中的 Star History 图表链接更新为新的数据源（star-history.dera.page），以恢复图表的正常展示。

## Summary by Sourcery

更新项目文档，以使用新的数据源恢复 Star History 图表显示。

Bug 修复：
- 通过指向可用的 star history 服务，修复主仓库和英文 README 中损坏的 Star History 图表链接。
- 修复日文和繁体中文文档页面中损坏的 Star History 图表链接，以恢复图表渲染。

文档更新：
- 在多语言 README 中更新所有 Star History 图表 URL，使其引用新的 `star-history.dera.page` 数据源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update project documentation to restore the Star History chart display using a new data source.

Bug Fixes:
- Fix broken Star History chart links in the main and English READMEs by pointing to a working star history service.
- Fix broken Star History chart links in Japanese and Traditional Chinese documentation pages to restore chart rendering.

Documentation:
- Update Star History chart URLs across multilingual READMEs to reference the new star-history.dera.page data source.

</details>