### PR TITLE
fix: migrate Mermaid rendering to Merman alpha.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@iconify/svelte": "^5.2.2",
     "@iconify/types": "^2.0.0",
     "@iconify/utils": "^3.1.4",
-    "@mermanjs/web": "0.8.0-alpha.3",
+    "@mermanjs/node": "0.8.0-alpha.5",
     "@napi-rs/wasm-runtime": "^1.2.2",
     "@swup/astro": "^1.8.0",
     "@tailwindcss/typography": "^0.5.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,9 @@ importers:
       '@iconify/utils':
         specifier: ^3.1.4
         version: 3.1.4
-      '@mermanjs/web':
-        specifier: 0.8.0-alpha.3
-        version: 0.8.0-alpha.3
+      '@mermanjs/node':
+        specifier: 0.8.0-alpha.5
+        version: 0.8.0-alpha.5
       '@napi-rs/wasm-runtime':
         specifier: ^1.2.2
         version: 1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
@@ -1923,8 +1923,41 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
-  '@mermanjs/web@0.8.0-alpha.3':
-    resolution: {integrity: sha512-nuZcWWc/I85RWuFraiJp9LbUIC7zEB+hdWic6TSjV26iRgD9tOE+o/MMH48/h5R10lr4uLz5ec7mhFUOgFARjQ==}
+  '@mermanjs/node-darwin-arm64@0.8.0-alpha.5':
+    resolution: {integrity: sha512-QvR5NN65u/Va22zTTXSy0+wJL7uu5IzK5YFry3s0rV7ey07MXmuF91pL4Zkyz0+Ust5KKZTouWD/Q1nYBM7UnQ==}
+    engines: {node: '>=22.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@mermanjs/node-darwin-x64@0.8.0-alpha.5':
+    resolution: {integrity: sha512-W5dARFPPFyL81viA4aQK/c0s4Y+2C9AehUD8W7f/k3SlKR6Xr1zKHUNi+xnZSBIz5y7viZ2GhdNoRYlbC4erVA==}
+    engines: {node: '>=22.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@mermanjs/node-linux-x64-gnu@0.8.0-alpha.5':
+    resolution: {integrity: sha512-BVus+FUAUveGXGkFlhzdlvI8D55b81AtdEi4hQ32G3VIv8Ca62FlSddWV4nJgcOfqVJC0qb114M/GwmP5s5hnw==}
+    engines: {node: '>=22.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@mermanjs/node-linux-x64-musl@0.8.0-alpha.5':
+    resolution: {integrity: sha512-qLfpTYw9BSBspKEMFFBpLI9pGuVcQzv4HjvglP1mu4p5ZwWBiX/jSCPhxA1IZGzwH5+XxXhNr+3qRNuuRLf8zQ==}
+    engines: {node: '>=22.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@mermanjs/node-win32-x64-msvc@0.8.0-alpha.5':
+    resolution: {integrity: sha512-4j53YFhfwBDWgnwKw2mL+R6lpYkCoMSlSUKYu5gECcIqQTszg/IHJQKwFubrOKExbFB5rw4Z+YKwflmeBnYvwg==}
+    engines: {node: '>=22.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@mermanjs/node@0.8.0-alpha.5':
+    resolution: {integrity: sha512-ubwlvOUK/JBgiOWo0/tDmDY0Q87TWSE9aBy/AuduI5AStWom8gBdye6RJB8TaDvbHiu5TbkrUTe+rPlZBRb52A==}
+    engines: {node: '>=22.0.0'}
 
   '@napi-rs/wasm-runtime@1.2.3':
     resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
@@ -7919,7 +7952,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mermanjs/web@0.8.0-alpha.3': {}
+  '@mermanjs/node-darwin-arm64@0.8.0-alpha.5':
+    optional: true
+
+  '@mermanjs/node-darwin-x64@0.8.0-alpha.5':
+    optional: true
+
+  '@mermanjs/node-linux-x64-gnu@0.8.0-alpha.5':
+    optional: true
+
+  '@mermanjs/node-linux-x64-musl@0.8.0-alpha.5':
+    optional: true
+
+  '@mermanjs/node-win32-x64-msvc@0.8.0-alpha.5':
+    optional: true
+
+  '@mermanjs/node@0.8.0-alpha.5':
+    optionalDependencies:
+      '@mermanjs/node-darwin-arm64': 0.8.0-alpha.5
+      '@mermanjs/node-darwin-x64': 0.8.0-alpha.5
+      '@mermanjs/node-linux-x64-gnu': 0.8.0-alpha.5
+      '@mermanjs/node-linux-x64-musl': 0.8.0-alpha.5
+      '@mermanjs/node-win32-x64-msvc': 0.8.0-alpha.5
 
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:

--- a/src/plugins/rehype-mermaid.mjs
+++ b/src/plugins/rehype-mermaid.mjs
@@ -1,5 +1,4 @@
-import { readFile } from "node:fs/promises";
-import { assertSafeSvgForDom, initMerman, renderSvg } from "@mermanjs/web";
+import { createNodeEngine } from "@mermanjs/node";
 import { h } from "hastscript";
 import { visit } from "unist-util-visit";
 import {
@@ -14,14 +13,18 @@ import {
 } from "./utils/diagramConstants.js";
 import { extractText } from "./utils/extractText.js";
 
-const mermanWasmUrl = import.meta.resolve(
-	"@mermanjs/web/pkg/merman_wasm_bg.wasm",
-);
-await initMerman({
-	wasm: {
-		module_or_path: await readFile(new URL(mermanWasmUrl)),
-	},
-});
+const mermanEngine = await createNodeEngine();
+
+// alpha.5 的主题预设不再设置 SVG 根背景色；显式保留 alpha.3 的画布颜色。
+const THEME_BACKGROUND_COLORS = {
+	"editor-light": "#ffffff",
+	"editor-dark": "#0f172a",
+	"one-dark": "#282c34",
+	"gruvbox-light": "#fbf1c7",
+	"gruvbox-dark": "#282828",
+	"ayu-light": "#fafafa",
+	"ayu-dark": "#0b0e14",
+};
 
 /**
  * 在构建时将 Mermaid 源码渲染为浅色和深色两套静态 SVG
@@ -39,24 +42,32 @@ function removeSvgMaxWidth(svg) {
 	return svg.replace(/(<svg[^>]*style="[^"]*?)max-width:\s*[^;]+;?/, "$1");
 }
 
-function buildMermaidSvgs(mermaidCode, themeConfig, diagramIndex) {
-	const lightSvg = renderSvg(mermaidCode, {
-		host_theme: { preset: themeConfig.lightTheme },
-		svg: {
-			diagram_id: `mermaid-${diagramIndex}-light`,
-			pipeline: "parity",
-		},
+function renderMermaidSvg(mermaidCode, theme, diagramId) {
+	return mermanEngine.renderSvgSync(mermaidCode, {
+		optionsJson: JSON.stringify({
+			presentation: {
+				theme: { preset: theme },
+			},
+			svg: {
+				diagram_id: diagramId,
+				pipeline: "parity",
+				root_background_color: THEME_BACKGROUND_COLORS[theme],
+			},
+		}),
 	});
-	const darkSvg = renderSvg(mermaidCode, {
-		host_theme: { preset: themeConfig.darkTheme },
-		svg: {
-			diagram_id: `mermaid-${diagramIndex}-dark`,
-			pipeline: "parity",
-		},
-	});
+}
 
-	assertSafeSvgForDom(lightSvg);
-	assertSafeSvgForDom(darkSvg);
+function buildMermaidSvgs(mermaidCode, themeConfig, diagramIndex) {
+	const lightSvg = renderMermaidSvg(
+		mermaidCode,
+		themeConfig.lightTheme,
+		`mermaid-${diagramIndex}-light`,
+	);
+	const darkSvg = renderMermaidSvg(
+		mermaidCode,
+		themeConfig.darkTheme,
+		`mermaid-${diagramIndex}-dark`,
+	);
 
 	return {
 		lightSvg: removeSvgMaxWidth(lightSvg),

--- a/src/types/mermaidConfig.ts
+++ b/src/types/mermaidConfig.ts
@@ -1,9 +1,14 @@
-import type { HostThemePresetName } from "@mermanjs/web";
-
 /**
  * merman 内置宿主主题预设名
  */
-export type MermaidThemeName = HostThemePresetName;
+export type MermaidThemeName =
+	| "editor-light"
+	| "editor-dark"
+	| "one-dark"
+	| "gruvbox-light"
+	| "gruvbox-dark"
+	| "ayu-light"
+	| "ayu-dark";
 
 /**
  * Mermaid 图表渲染配置


### PR DESCRIPTION
## Summary

Updating `@mermanjs/web` from 0.8.0-alpha.3 to alpha.5 is not a drop-in dependency bump. Alpha.5 is a breaking prerelease that changes the public APIs and package layout, which is why the dependency-only update in #572 fails to build.

This PR proposes one migration path: move Firefly's build-time Mermaid rendering to `@mermanjs/node`, which Merman documents as its Node.js and static-site generation surface. The trade-offs are documented below so maintainers can decide whether this path is appropriate for Firefly.

## Changes

- Replaced `@mermanjs/web` 0.8.0-alpha.3 with `@mermanjs/node` 0.8.0-alpha.5.
- Removed direct loading of the internal `pkg/**` WASM file and now reuse a single Node engine with its synchronous SSG rendering API.
- Migrated the removed `host_theme` option to the alpha.5 `presentation.theme` and `svg` option schema.
- Preserved the light/dark SVG IDs and the `parity` pipeline.
- Explicitly preserved the alpha.3 canvas colors for all seven theme presets because alpha.5 presets no longer set the root SVG background on their own.
- Replaced the removed `HostThemePresetName` export with a local union of the presets supported by Firefly.

## Validation

- `pnpm check` — passed: 237 files, 0 errors, 0 warnings
- `pnpm exec biome check src/plugins/rehype-mermaid.mjs src/types/mermaidConfig.ts` — passed
- `pnpm build` — passed: 35 pages generated
- `pnpm astro build --force` — passed: verified a complete rerender with the content cache cleared
- Local preview — verified 14 Mermaid examples, 28 light/dark SVGs, and 0 rendering errors
- Local preview — verified an `#0f172a` background for the `editor-dark` SVG and `#ffffff` for the light SVG
- [Netlify Deploy Preview](https://deploy-preview-584--demo-firefly.netlify.app/posts/markdown-mermaid/) — passed
- `pnpm type-check` — failed on existing implicit `any` and generic-related errors in untouched files: `src/pages/api/dynamic.json.ts`, `src/pages/og/[...slug].ts`, and `src/utils/content-utils.ts`

## Notes

Related: #572

`@mermanjs/node` 0.8.0-alpha.5 is experimental. It supports Node.js 22+ on macOS arm64/x64, Linux x64 with glibc or musl, and Windows x64 MSVC. Firefly's current Node.js requirement of `>=22.23.0` satisfies the version constraint, but environments such as Linux arm64 are not supported.

The Node surface does not include a browser-WASM fallback, math rendering, or browser DOM-admission APIs. Consequently, this PR cannot retain the existing `assertSafeSvgForDom()` call and instead treats SVG generated by Merman during the trusted SSG build as trusted output. If Mermaid math rendering or a separate DOM-admission check is required by Firefly, keeping alpha.3 until Merman expands the Node surface would be the safer choice.

If these constraints are acceptable, this PR can replace the dependency-only update in #572.

## Summary by Sourcery

将 Mermaid 的静态渲染迁移到 Merman Node alpha.5，同时保留 Firefly 现有的主题化 SVG 输出效果。

Bug Fixes:
- 将构建时的 Mermaid 渲染迁移到 Merman Node alpha.5 API，以便在有破坏性变更的预发布更新下，静态站点生成仍然保持兼容。

Enhancements:
- 保留明亮和暗色 SVG 输出、图表标识符、对称渲染行为，以及在受支持的 Mermaid 主题中既有的背景颜色。
- 用通过共享 Node 引擎进行的同步渲染，替代直接加载 WASM 和面向浏览器的 SVG 注入方式。
- 在本地定义 Firefly 支持的 Mermaid 主题预设，以兼容更新后的包 API。

Build:
- 将 `@mermanjs/web` alpha.3 替换为 `@mermanjs/node` alpha.5，并更新 lockfile。

Tests:
- 验证格式、静态站点构建、完整内容再生成，以及在明亮和暗色主题下的 Mermaid 渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate Mermaid static rendering to Merman Node alpha.5 while preserving Firefly’s existing themed SVG output.

Bug Fixes:
- Migrate build-time Mermaid rendering to the Merman Node alpha.5 API so static site generation remains compatible with the breaking prerelease update.

Enhancements:
- Preserve light and dark SVG output, diagram identifiers, parity rendering, and the established background colors across supported Mermaid themes.
- Replace direct WASM loading and browser-oriented SVG admission with synchronous rendering through a shared Node engine.
- Define Firefly’s supported Mermaid theme presets locally for compatibility with the updated package API.

Build:
- Replace @mermanjs/web alpha.3 with @mermanjs/node alpha.5 and update the lockfile.

Tests:
- Validate formatting, static site builds, full content regeneration, and Mermaid rendering across light and dark themes.

</details>

Bug Fixes（错误修复）:
- 将 Mermaid 渲染迁移到 Merman Node alpha.5 API，以便在存在破坏性预发布更新的情况下，静态站点构建仍然保持兼容。

Enhancements（增强）:
- 在新渲染器上保留明/暗主题渲染、图表标识符、一致的输出以及特定主题的 SVG 背景。
- 用通过 Node 引擎在构建阶段同步渲染的方式，替换直接加载 WASM 和基于 DOM 的 SVG 校验。
- 在本地定义 Firefly 支持的 Mermaid 主题预设，以匹配更新后的包 API。

Build（构建）:
- 将 `@mermanjs/web 0.8.0-alpha.3` 替换为 `@mermanjs/node 0.8.0-alpha.5`，并更新锁文件（lockfile）。

Tests（测试）:
- 验证类型检查、格式化、站点构建、完整内容再生成，以及在明暗主题下的 Mermaid 预览渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 Mermaid 的静态渲染迁移到 Merman Node alpha.5，同时保留 Firefly 现有的主题化 SVG 输出效果。

Bug Fixes:
- 将构建时的 Mermaid 渲染迁移到 Merman Node alpha.5 API，以便在有破坏性变更的预发布更新下，静态站点生成仍然保持兼容。

Enhancements:
- 保留明亮和暗色 SVG 输出、图表标识符、对称渲染行为，以及在受支持的 Mermaid 主题中既有的背景颜色。
- 用通过共享 Node 引擎进行的同步渲染，替代直接加载 WASM 和面向浏览器的 SVG 注入方式。
- 在本地定义 Firefly 支持的 Mermaid 主题预设，以兼容更新后的包 API。

Build:
- 将 `@mermanjs/web` alpha.3 替换为 `@mermanjs/node` alpha.5，并更新 lockfile。

Tests:
- 验证格式、静态站点构建、完整内容再生成，以及在明亮和暗色主题下的 Mermaid 渲染。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate Mermaid static rendering to Merman Node alpha.5 while preserving Firefly’s existing themed SVG output.

Bug Fixes:
- Migrate build-time Mermaid rendering to the Merman Node alpha.5 API so static site generation remains compatible with the breaking prerelease update.

Enhancements:
- Preserve light and dark SVG output, diagram identifiers, parity rendering, and the established background colors across supported Mermaid themes.
- Replace direct WASM loading and browser-oriented SVG admission with synchronous rendering through a shared Node engine.
- Define Firefly’s supported Mermaid theme presets locally for compatibility with the updated package API.

Build:
- Replace @mermanjs/web alpha.3 with @mermanjs/node alpha.5 and update the lockfile.

Tests:
- Validate formatting, static site builds, full content regeneration, and Mermaid rendering across light and dark themes.

</details>

</details>