### PR TITLE
Revert "fix: migrate Mermaid rendering to Merman alpha.5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@iconify/svelte": "^5.2.2",
     "@iconify/types": "^2.0.0",
     "@iconify/utils": "^3.1.4",
-    "@mermanjs/node": "0.8.0-alpha.5",
+    "@mermanjs/web": "0.8.0-alpha.3",
     "@napi-rs/wasm-runtime": "^1.2.2",
     "@swup/astro": "^1.8.0",
     "@tailwindcss/typography": "^0.5.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,9 +68,9 @@ importers:
       '@iconify/utils':
         specifier: ^3.1.4
         version: 3.1.4
-      '@mermanjs/node':
-        specifier: 0.8.0-alpha.5
-        version: 0.8.0-alpha.5
+      '@mermanjs/web':
+        specifier: 0.8.0-alpha.3
+        version: 0.8.0-alpha.3
       '@napi-rs/wasm-runtime':
         specifier: ^1.2.2
         version: 1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
@@ -1923,41 +1923,8 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
-  '@mermanjs/node-darwin-arm64@0.8.0-alpha.5':
-    resolution: {integrity: sha512-QvR5NN65u/Va22zTTXSy0+wJL7uu5IzK5YFry3s0rV7ey07MXmuF91pL4Zkyz0+Ust5KKZTouWD/Q1nYBM7UnQ==}
-    engines: {node: '>=22.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@mermanjs/node-darwin-x64@0.8.0-alpha.5':
-    resolution: {integrity: sha512-W5dARFPPFyL81viA4aQK/c0s4Y+2C9AehUD8W7f/k3SlKR6Xr1zKHUNi+xnZSBIz5y7viZ2GhdNoRYlbC4erVA==}
-    engines: {node: '>=22.0.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@mermanjs/node-linux-x64-gnu@0.8.0-alpha.5':
-    resolution: {integrity: sha512-BVus+FUAUveGXGkFlhzdlvI8D55b81AtdEi4hQ32G3VIv8Ca62FlSddWV4nJgcOfqVJC0qb114M/GwmP5s5hnw==}
-    engines: {node: '>=22.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@mermanjs/node-linux-x64-musl@0.8.0-alpha.5':
-    resolution: {integrity: sha512-qLfpTYw9BSBspKEMFFBpLI9pGuVcQzv4HjvglP1mu4p5ZwWBiX/jSCPhxA1IZGzwH5+XxXhNr+3qRNuuRLf8zQ==}
-    engines: {node: '>=22.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@mermanjs/node-win32-x64-msvc@0.8.0-alpha.5':
-    resolution: {integrity: sha512-4j53YFhfwBDWgnwKw2mL+R6lpYkCoMSlSUKYu5gECcIqQTszg/IHJQKwFubrOKExbFB5rw4Z+YKwflmeBnYvwg==}
-    engines: {node: '>=22.0.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@mermanjs/node@0.8.0-alpha.5':
-    resolution: {integrity: sha512-ubwlvOUK/JBgiOWo0/tDmDY0Q87TWSE9aBy/AuduI5AStWom8gBdye6RJB8TaDvbHiu5TbkrUTe+rPlZBRb52A==}
-    engines: {node: '>=22.0.0'}
+  '@mermanjs/web@0.8.0-alpha.3':
+    resolution: {integrity: sha512-nuZcWWc/I85RWuFraiJp9LbUIC7zEB+hdWic6TSjV26iRgD9tOE+o/MMH48/h5R10lr4uLz5ec7mhFUOgFARjQ==}
 
   '@napi-rs/wasm-runtime@1.2.3':
     resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
@@ -7952,28 +7919,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mermanjs/node-darwin-arm64@0.8.0-alpha.5':
-    optional: true
-
-  '@mermanjs/node-darwin-x64@0.8.0-alpha.5':
-    optional: true
-
-  '@mermanjs/node-linux-x64-gnu@0.8.0-alpha.5':
-    optional: true
-
-  '@mermanjs/node-linux-x64-musl@0.8.0-alpha.5':
-    optional: true
-
-  '@mermanjs/node-win32-x64-msvc@0.8.0-alpha.5':
-    optional: true
-
-  '@mermanjs/node@0.8.0-alpha.5':
-    optionalDependencies:
-      '@mermanjs/node-darwin-arm64': 0.8.0-alpha.5
-      '@mermanjs/node-darwin-x64': 0.8.0-alpha.5
-      '@mermanjs/node-linux-x64-gnu': 0.8.0-alpha.5
-      '@mermanjs/node-linux-x64-musl': 0.8.0-alpha.5
-      '@mermanjs/node-win32-x64-msvc': 0.8.0-alpha.5
+  '@mermanjs/web@0.8.0-alpha.3': {}
 
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:

--- a/src/plugins/rehype-mermaid.mjs
+++ b/src/plugins/rehype-mermaid.mjs
@@ -1,4 +1,5 @@
-import { createNodeEngine } from "@mermanjs/node";
+import { readFile } from "node:fs/promises";
+import { assertSafeSvgForDom, initMerman, renderSvg } from "@mermanjs/web";
 import { h } from "hastscript";
 import { visit } from "unist-util-visit";
 import {
@@ -13,18 +14,14 @@ import {
 } from "./utils/diagramConstants.js";
 import { extractText } from "./utils/extractText.js";
 
-const mermanEngine = await createNodeEngine();
-
-// alpha.5 的主题预设不再设置 SVG 根背景色；显式保留 alpha.3 的画布颜色。
-const THEME_BACKGROUND_COLORS = {
-	"editor-light": "#ffffff",
-	"editor-dark": "#0f172a",
-	"one-dark": "#282c34",
-	"gruvbox-light": "#fbf1c7",
-	"gruvbox-dark": "#282828",
-	"ayu-light": "#fafafa",
-	"ayu-dark": "#0b0e14",
-};
+const mermanWasmUrl = import.meta.resolve(
+	"@mermanjs/web/pkg/merman_wasm_bg.wasm",
+);
+await initMerman({
+	wasm: {
+		module_or_path: await readFile(new URL(mermanWasmUrl)),
+	},
+});
 
 /**
  * 在构建时将 Mermaid 源码渲染为浅色和深色两套静态 SVG
@@ -42,32 +39,24 @@ function removeSvgMaxWidth(svg) {
 	return svg.replace(/(<svg[^>]*style="[^"]*?)max-width:\s*[^;]+;?/, "$1");
 }
 
-function renderMermaidSvg(mermaidCode, theme, diagramId) {
-	return mermanEngine.renderSvgSync(mermaidCode, {
-		optionsJson: JSON.stringify({
-			presentation: {
-				theme: { preset: theme },
-			},
-			svg: {
-				diagram_id: diagramId,
-				pipeline: "parity",
-				root_background_color: THEME_BACKGROUND_COLORS[theme],
-			},
-		}),
-	});
-}
-
 function buildMermaidSvgs(mermaidCode, themeConfig, diagramIndex) {
-	const lightSvg = renderMermaidSvg(
-		mermaidCode,
-		themeConfig.lightTheme,
-		`mermaid-${diagramIndex}-light`,
-	);
-	const darkSvg = renderMermaidSvg(
-		mermaidCode,
-		themeConfig.darkTheme,
-		`mermaid-${diagramIndex}-dark`,
-	);
+	const lightSvg = renderSvg(mermaidCode, {
+		host_theme: { preset: themeConfig.lightTheme },
+		svg: {
+			diagram_id: `mermaid-${diagramIndex}-light`,
+			pipeline: "parity",
+		},
+	});
+	const darkSvg = renderSvg(mermaidCode, {
+		host_theme: { preset: themeConfig.darkTheme },
+		svg: {
+			diagram_id: `mermaid-${diagramIndex}-dark`,
+			pipeline: "parity",
+		},
+	});
+
+	assertSafeSvgForDom(lightSvg);
+	assertSafeSvgForDom(darkSvg);
 
 	return {
 		lightSvg: removeSvgMaxWidth(lightSvg),

--- a/src/types/mermaidConfig.ts
+++ b/src/types/mermaidConfig.ts
@@ -1,14 +1,9 @@
+import type { HostThemePresetName } from "@mermanjs/web";
+
 /**
  * merman 内置宿主主题预设名
  */
-export type MermaidThemeName =
-	| "editor-light"
-	| "editor-dark"
-	| "one-dark"
-	| "gruvbox-light"
-	| "gruvbox-dark"
-	| "ayu-light"
-	| "ayu-dark";
+export type MermaidThemeName = HostThemePresetName;
 
 /**
  * Mermaid 图表渲染配置


### PR DESCRIPTION
Reverts CuteLeaf/Firefly#584

## Summary by Sourcery

还原 Mermaid 渲染器迁移，恢复之前基于 Web 的渲染集成。

Bug 修复：
- 将 Mermaid 渲染恢复为基于 Web 的 Merman alpha.3 集成。

构建：
- 将 Merman Node alpha.5 依赖替换为 Merman Web alpha.3 依赖，并更新 lockfile。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the Mermaid renderer migration to restore the previous web-based rendering integration.

Bug Fixes:
- Restore Mermaid rendering to the web-based Merman alpha.3 integration.

Build:
- Replace the Merman Node alpha.5 dependency with the Merman Web alpha.3 dependency and update the lockfile.

</details>