### PR TITLE
fix(layout): forward page head slot

### DIFF
--- a/src/components/layout/HeaderTopRow.astro
+++ b/src/components/layout/HeaderTopRow.astro
@@ -10,7 +10,6 @@ const { stickyNavbar, navbarWidthFull } = Astro.props;
 ---
 
 <!-- 导航栏外壳（从 MainGridLayout.astro 迁出） -->
-<slot slot="head" name="head" />
 <div
     id="top-row"
     class="z-50 pointer-events-none relative transition-all duration-700 mx-auto"

--- a/src/layouts/MainGridLayout.astro
+++ b/src/layouts/MainGridLayout.astro
@@ -82,6 +82,7 @@ const {
 
 <Layout title={title} description={description} lang={lang} setOGTypeArticle={setOGTypeArticle} postSlug={postSlug} hasWallpaper={hasWallpaper}>
 
+<slot slot="head" name="head" />
 <HeaderTopRow stickyNavbar={stickyNavbar} navbarWidthFull={navbarWidthFull} />
 
 <WallpaperSection state={banner} backgroundImages={backgroundImages} title={title} bannerPostMeta={bannerPostMeta} />


### PR DESCRIPTION
## Summary

Fix a regression where pages using `MainGridLayout` no longer forwarded their named `head` slot to the top-level `Layout`. As a result, the friends page filter script was omitted from the final HTML and the `Blog`, `Docs`, and `Framework` buttons did nothing.

## Changes

- Restore direct forwarding of the page-level `head` slot from `MainGridLayout` to `Layout`.
- Remove the unused empty slot forwarding from `HeaderTopRow`, which never received page-level head content.
- Restore rendering of inline scripts for the friends, bookmarks, and gallery pages, as well as KaTeX and JSON-LD head content for posts.

## Validation

- `pnpm check` — passed (0 errors, 0 warnings, 0 hints)
- `pnpm type-check` — passed
- `pnpm build` — passed (35 pages built)
- Verified the `Blog` and `Docs` filters after loading `/friends/` directly in a local browser.
- Verified the `Blog` filter after navigating from the home page to `/friends/` through Swup.
- Confirmed that `dist/friends/index.html` contains the `friend-filter` definition and that generated post HTML contains `application/ld+json`.
