### PR TITLE
fix: render GitHub cards from build cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "check": "astro check",
-    "build": "npx tsx scripts/generate-lqips.ts && npx tsx scripts/generate-vndb-covers.ts && astro build && npx tsx scripts/prune-pio-assets.ts && npx tsx scripts/subset-fonts.ts && npx tsx scripts/minify-inline-scripts.ts && pagefind --site dist",
+    "build": "npx tsx scripts/generate-github-card-data.ts && npx tsx scripts/generate-lqips.ts && npx tsx scripts/generate-vndb-covers.ts && astro build && npx tsx scripts/prune-pio-assets.ts && npx tsx scripts/subset-fonts.ts && npx tsx scripts/minify-inline-scripts.ts && pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
     "type-check": "tsc --noEmit --isolatedDeclarations",
@@ -20,7 +20,8 @@
     "format": "biome format --write ./src ./scripts",
     "lint": "biome check --write ./src ./scripts",
     "preinstall": "npx only-allow pnpm",
-    "lqips": "npx tsx scripts/generate-lqips.ts"
+    "lqips": "npx tsx scripts/generate-lqips.ts",
+    "github-cards": "npx tsx scripts/generate-github-card-data.ts"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.10",

--- a/scripts/generate-github-card-data.ts
+++ b/scripts/generate-github-card-data.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { glob } from "glob";
+
+const OUTPUT_FILE = "src/constants/github-card-data.json";
+const CONTENT_GLOB = "src/content/**/*.{md,mdx}";
+const GITHUB_DIRECTIVE_PATTERN =
+	/::github\s*\{[^}]*\brepo\s*=\s*["']([^"']+)["'][^}]*\}/g;
+const REPOSITORY_PATTERN = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
+
+interface GithubCardData {
+	description: string | null;
+	language: string | null;
+	forks: number;
+	stars: number;
+	avatarUrl: string | null;
+	license: string | null;
+}
+
+type GithubCardCache = Record<string, GithubCardData>;
+
+async function readCache(): Promise<GithubCardCache> {
+	try {
+		return JSON.parse(await fs.readFile(OUTPUT_FILE, "utf-8"));
+	} catch {
+		return {};
+	}
+}
+
+async function findRepositories(): Promise<Map<string, string>> {
+	const repositories = new Map<string, string>();
+	const contentFiles = await glob(CONTENT_GLOB);
+
+	for (const file of contentFiles) {
+		const content = await fs.readFile(file, "utf-8");
+		for (const match of content.matchAll(GITHUB_DIRECTIVE_PATTERN)) {
+			const repo = match[1];
+			if (REPOSITORY_PATTERN.test(repo)) {
+				repositories.set(repo.toLowerCase(), repo);
+			}
+		}
+	}
+
+	return repositories;
+}
+
+async function fetchRepositoryData(repo: string): Promise<GithubCardData> {
+	const [owner, name] = repo.split("/");
+	const headers: Record<string, string> = {
+		Accept: "application/vnd.github+json",
+		"X-GitHub-Api-Version": "2022-11-28",
+	};
+	const token = process.env.GITHUB_TOKEN?.trim();
+	if (token) headers.Authorization = `Bearer ${token}`;
+
+	const response = await fetch(
+		`https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`,
+		{
+			headers,
+			signal: AbortSignal.timeout(5000),
+		},
+	);
+	if (!response.ok) {
+		throw new Error(`GitHub API returned ${response.status}`);
+	}
+
+	const data = await response.json();
+	return {
+		description:
+			typeof data.description === "string"
+				? data.description.replace(/:[a-zA-Z0-9_]+:/g, "")
+				: null,
+		language: typeof data.language === "string" ? data.language : null,
+		forks: typeof data.forks === "number" ? data.forks : 0,
+		stars:
+			typeof data.stargazers_count === "number" ? data.stargazers_count : 0,
+		avatarUrl:
+			typeof data.owner?.avatar_url === "string" ? data.owner.avatar_url : null,
+		license:
+			typeof data.license?.spdx_id === "string" ? data.license.spdx_id : null,
+	};
+}
+
+async function main() {
+	const existingCache = await readCache();
+	const repositories = await findRepositories();
+	const nextCache: GithubCardCache = {};
+	let updated = 0;
+
+	for (const [cacheKey, repo] of repositories) {
+		try {
+			nextCache[cacheKey] = await fetchRepositoryData(repo);
+			updated++;
+		} catch (error) {
+			if (existingCache[cacheKey]) {
+				nextCache[cacheKey] = existingCache[cacheKey];
+				console.warn(
+					`[GITHUB-CARD] Failed to refresh ${repo}; keeping cached data.`,
+					error,
+				);
+			} else {
+				console.warn(
+					`[GITHUB-CARD] Failed to load ${repo}; the card will use its fallback state.`,
+					error,
+				);
+			}
+		}
+	}
+
+	const sortedCache = Object.fromEntries(
+		Object.entries(nextCache).sort(([a], [b]) => a.localeCompare(b)),
+	);
+	await fs.mkdir(path.dirname(OUTPUT_FILE), { recursive: true });
+	await fs.writeFile(
+		OUTPUT_FILE,
+		`${JSON.stringify(sortedCache, null, "\t")}\n`,
+	);
+	console.log(
+		`[GITHUB-CARD] Cached ${Object.keys(sortedCache).length} repositories (${updated} refreshed).`,
+	);
+}
+
+main();

--- a/scripts/generate-github-card-data.ts
+++ b/scripts/generate-github-card-data.ts
@@ -1,12 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { glob } from "glob";
+import { isValidGithubRepository } from "../src/utils/github-card-utils";
 
 const OUTPUT_FILE = "src/constants/github-card-data.json";
 const CONTENT_GLOB = "src/content/**/*.{md,mdx}";
 const GITHUB_DIRECTIVE_PATTERN =
 	/::github\s*\{[^}]*\brepo\s*=\s*["']([^"']+)["'][^}]*\}/g;
-const REPOSITORY_PATTERN = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
 
 interface GithubCardData {
 	description: string | null;
@@ -35,7 +35,7 @@ async function findRepositories(): Promise<Map<string, string>> {
 		const content = await fs.readFile(file, "utf-8");
 		for (const match of content.matchAll(GITHUB_DIRECTIVE_PATTERN)) {
 			const repo = match[1];
-			if (REPOSITORY_PATTERN.test(repo)) {
+			if (isValidGithubRepository(repo)) {
 				repositories.set(repo.toLowerCase(), repo);
 			}
 		}
@@ -61,7 +61,9 @@ async function fetchRepositoryData(repo: string): Promise<GithubCardData> {
 		},
 	);
 	if (!response.ok) {
-		throw new Error(`GitHub API returned ${response.status}`);
+		throw new Error(
+			`GitHub API returned ${response.status}${response.statusText ? ` ${response.statusText}` : ""}`,
+		);
 	}
 
 	const data = await response.json();

--- a/src/constants/github-card-data.json
+++ b/src/constants/github-card-data.json
@@ -1,0 +1,18 @@
+{
+	"cuteleaf/firefly": {
+		"description": "🍀Firefly, fresh and aesthetic Astro blog theme template. ",
+		"language": "Astro",
+		"forks": 1535,
+		"stars": 1953,
+		"avatarUrl": "https://avatars.githubusercontent.com/u/43440669?v=4",
+		"license": "MIT"
+	},
+	"saicaca/fuwari": {
+		"description": "✨A static blog template built with Astro. ",
+		"language": "Astro",
+		"forks": 1243,
+		"stars": 4935,
+		"avatarUrl": "https://avatars.githubusercontent.com/u/25200299?v=4",
+		"license": "MIT"
+	}
+}

--- a/src/plugins/rehype-component-github-card.mjs
+++ b/src/plugins/rehype-component-github-card.mjs
@@ -3,12 +3,7 @@ import { h } from "hastscript";
 import githubCardData from "../constants/github-card-data.json" with {
 	type: "json",
 };
-
-function isValidRepository(repo) {
-	return (
-		typeof repo === "string" && /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/.test(repo)
-	);
-}
+import { isValidGithubRepository } from "../utils/github-card-utils.ts";
 
 function formatCount(value) {
 	return Intl.NumberFormat("en-us", {
@@ -33,7 +28,7 @@ export function GithubCardComponent(properties, children) {
 			'Invalid directive. ("github" directive must be leaf type "::github{repo="owner/repo"}")',
 		]);
 
-	if (!isValidRepository(properties.repo))
+	if (!isValidGithubRepository(properties.repo))
 		return h(
 			"div",
 			{ class: "hidden" },

--- a/src/plugins/rehype-component-github-card.mjs
+++ b/src/plugins/rehype-component-github-card.mjs
@@ -58,7 +58,10 @@ export function GithubCardComponent(properties, children) {
 		`script#${cardUuid}-script`,
 		{ type: "text/javascript", defer: true },
 		`
-      fetch('https://api.github.com/repos/${repo}', { referrerPolicy: "no-referrer" }).then(response => response.json()).then(data => {
+      fetch('https://api.github.com/repos/${repo}', { referrerPolicy: "no-referrer" }).then(response => {
+        if (!response.ok) throw new Error(\`GitHub API returned \${response.status}\`);
+        return response.json();
+      }).then(data => {
         document.getElementById('${cardUuid}-description').innerText = data.description?.replace(/:[a-zA-Z0-9_]+:/g, '') || "Description not set";
         document.getElementById('${cardUuid}-language').innerText = data.language;
         document.getElementById('${cardUuid}-forks').innerText = Intl.NumberFormat('en-us', { notation: "compact", maximumFractionDigits: 1 }).format(data.forks).replaceAll("\u202f", '');
@@ -71,8 +74,14 @@ export function GithubCardComponent(properties, children) {
         console.log("[GITHUB-CARD] Loaded card for ${repo} | ${cardUuid}.")
       }).catch(err => {
         const c = document.getElementById('${cardUuid}-card');
+        document.getElementById('${cardUuid}-description').innerText = "Repository details unavailable";
+        document.getElementById('${cardUuid}-language').innerText = "Unavailable";
+        document.getElementById('${cardUuid}-forks').innerText = "—";
+        document.getElementById('${cardUuid}-stars').innerText = "—";
+        document.getElementById('${cardUuid}-license').innerText = "—";
+        c?.classList.remove("fetch-waiting");
         c?.classList.add("fetch-error");
-        console.warn("[GITHUB-CARD] (Error) Loading card for ${repo} | ${cardUuid}.")
+        console.warn("[GITHUB-CARD] (Error) Loading card for ${repo} | ${cardUuid}.", err)
       })
     `,
 	);

--- a/src/plugins/rehype-component-github-card.mjs
+++ b/src/plugins/rehype-component-github-card.mjs
@@ -1,5 +1,23 @@
 /// <reference types="mdast" />
 import { h } from "hastscript";
+import githubCardData from "../constants/github-card-data.json" with {
+	type: "json",
+};
+
+function isValidRepository(repo) {
+	return (
+		typeof repo === "string" && /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/.test(repo)
+	);
+}
+
+function formatCount(value) {
+	return Intl.NumberFormat("en-us", {
+		notation: "compact",
+		maximumFractionDigits: 1,
+	})
+		.format(value)
+		.replaceAll("\u202f", "");
+}
 
 /**
  * Creates a GitHub Card component.
@@ -15,7 +33,7 @@ export function GithubCardComponent(properties, children) {
 			'Invalid directive. ("github" directive must be leaf type "::github{repo="owner/repo"}")',
 		]);
 
-	if (!properties.repo?.includes("/"))
+	if (!isValidRepository(properties.repo))
 		return h(
 			"div",
 			{ class: "hidden" },
@@ -24,12 +42,23 @@ export function GithubCardComponent(properties, children) {
 
 	const repo = properties.repo;
 	const cardUuid = `GC${Math.random().toString(36).slice(-6)}`; // Collisions are not important
+	const data = githubCardData[repo.toLowerCase()] ?? null;
+	const hasData = data !== null;
 
-	const nAvatar = h(`div#${cardUuid}-avatar`, { class: "gc-avatar" });
+	const avatarUrl = data?.avatarUrl
+		? `${data.avatarUrl}${data.avatarUrl.includes("?") ? "&" : "?"}s=32`
+		: null;
+	const avatarStyle = avatarUrl
+		? `background-image: url("${avatarUrl}"); background-color: transparent;`
+		: undefined;
+	const nAvatar = h(`div#${cardUuid}-avatar`, {
+		class: "gc-avatar",
+		style: avatarStyle,
+	});
 	const nLanguage = h(
 		`span#${cardUuid}-language`,
 		{ class: "gc-language" },
-		"Waiting...",
+		data?.language ?? "Unavailable",
 	);
 
 	const nTitle = h("div", { class: "gc-titlebar" }, [
@@ -47,49 +76,31 @@ export function GithubCardComponent(properties, children) {
 	const nDescription = h(
 		`div#${cardUuid}-description`,
 		{ class: "gc-description" },
-		"Waiting for api.github.com...",
+		hasData
+			? data.description || "Description not set"
+			: "Repository details unavailable",
 	);
 
-	const nStars = h(`div#${cardUuid}-stars`, { class: "gc-stars" }, "00K");
-	const nForks = h(`div#${cardUuid}-forks`, { class: "gc-forks" }, "0K");
-	const nLicense = h(`div#${cardUuid}-license`, { class: "gc-license" }, "0K");
-
-	const nScript = h(
-		`script#${cardUuid}-script`,
-		{ type: "text/javascript", defer: true },
-		`
-      fetch('https://api.github.com/repos/${repo}', { referrerPolicy: "no-referrer" }).then(response => {
-        if (!response.ok) throw new Error(\`GitHub API returned \${response.status}\`);
-        return response.json();
-      }).then(data => {
-        document.getElementById('${cardUuid}-description').innerText = data.description?.replace(/:[a-zA-Z0-9_]+:/g, '') || "Description not set";
-        document.getElementById('${cardUuid}-language').innerText = data.language;
-        document.getElementById('${cardUuid}-forks').innerText = Intl.NumberFormat('en-us', { notation: "compact", maximumFractionDigits: 1 }).format(data.forks).replaceAll("\u202f", '');
-        document.getElementById('${cardUuid}-stars').innerText = Intl.NumberFormat('en-us', { notation: "compact", maximumFractionDigits: 1 }).format(data.stargazers_count).replaceAll("\u202f", '');
-        const avatarEl = document.getElementById('${cardUuid}-avatar');
-        avatarEl.style.backgroundImage = 'url(' + data.owner.avatar_url + '&s=32' + ')';
-        avatarEl.style.backgroundColor = 'transparent';
-        document.getElementById('${cardUuid}-license').innerText = data.license?.spdx_id || "no-license";
-        document.getElementById('${cardUuid}-card').classList.remove("fetch-waiting");
-        console.log("[GITHUB-CARD] Loaded card for ${repo} | ${cardUuid}.")
-      }).catch(err => {
-        const c = document.getElementById('${cardUuid}-card');
-        document.getElementById('${cardUuid}-description').innerText = "Repository details unavailable";
-        document.getElementById('${cardUuid}-language').innerText = "Unavailable";
-        document.getElementById('${cardUuid}-forks').innerText = "—";
-        document.getElementById('${cardUuid}-stars').innerText = "—";
-        document.getElementById('${cardUuid}-license').innerText = "—";
-        c?.classList.remove("fetch-waiting");
-        c?.classList.add("fetch-error");
-        console.warn("[GITHUB-CARD] (Error) Loading card for ${repo} | ${cardUuid}.", err)
-      })
-    `,
+	const nStars = h(
+		`div#${cardUuid}-stars`,
+		{ class: "gc-stars" },
+		hasData ? formatCount(data.stars) : "—",
+	);
+	const nForks = h(
+		`div#${cardUuid}-forks`,
+		{ class: "gc-forks" },
+		hasData ? formatCount(data.forks) : "—",
+	);
+	const nLicense = h(
+		`div#${cardUuid}-license`,
+		{ class: "gc-license" },
+		hasData ? data.license || "no-license" : "—",
 	);
 
 	return h(
 		`a#${cardUuid}-card`,
 		{
-			class: "card-github fetch-waiting no-styling",
+			class: `card-github${hasData ? "" : " fetch-error"} no-styling`,
 			href: `https://github.com/${repo}`,
 			target: "_blank",
 			repo,
@@ -98,7 +109,6 @@ export function GithubCardComponent(properties, children) {
 			nTitle,
 			nDescription,
 			h("div", { class: "gc-infobar" }, [nStars, nForks, nLicense, nLanguage]),
-			nScript,
 		],
 	);
 }

--- a/src/utils/github-card-utils.ts
+++ b/src/utils/github-card-utils.ts
@@ -1,0 +1,5 @@
+const GITHUB_REPOSITORY_PATTERN = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
+
+export function isValidGithubRepository(repo: unknown): repo is string {
+	return typeof repo === "string" && GITHUB_REPOSITORY_PATTERN.test(repo);
+}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

None.

## Changes

- Generate GitHub repository card metadata at build time instead of fetching it in every visitor's browser.
- Scan Markdown and MDX content for unique `::github` directives and store their public metadata in a generated cache.
- Reuse the last successful cache entry when GitHub is unavailable or rate-limited, so builds remain resilient.
- Support an optional build-only `GITHUB_TOKEN` for a higher API rate limit without exposing it in generated HTML.
- Render repository descriptions, counts, avatars, and licenses directly into static HTML with no client-side GitHub API script.
- Keep a readable fallback card and usable repository link when no cached entry exists.

Previously, each card made an unauthenticated browser request. A rate-limit response was treated as repository data, resulting in `NaN` values and a card stuck in its loading state. Static build-time rendering removes the per-visitor API dependency entirely.

## How To Test

- `pnpm github-cards` — passed while refreshing both repositories.
- Verified a real `403` response preserves both existing cache entries and exits successfully.
- `pnpm exec biome check scripts/generate-github-card-data.ts src/plugins/rehype-component-github-card.mjs src/constants/github-card-data.json astro.config.mjs` — passed.
- `pnpm check` — passed with 0 errors, warnings, or hints.
- `pnpm type-check` — passed.
- `pnpm build` — passed, including the GitHub cache generation step.
- Inspected the generated `/about/` HTML: cached metadata is present, with no `api.github.com` request, card `<script>`, or `fetch-waiting` state.
- Verified the production build in a browser: both cards render their cached description, stars, forks, and license immediately with no GitHub-card console errors.

## Screenshots (if applicable)

Not included. The existing card layout is unchanged; only its data source and loading behavior changed.

## Additional Notes

The generated cache contains only public repository metadata. `GITHUB_TOKEN`, when provided to the build process, is used only for the server-side API request and is never serialized into site output.

## 由 Sourcery 提供的摘要

将 GitHub 卡片数据的获取移至构建流程中，以便仓库卡片可以静态渲染，并在 API 不可用或受限时保持可靠。

Bug 修复：
- 从构建时生成的元数据中渲染 GitHub 仓库卡片，而不是在浏览器端通过 API 请求获取，从而避免因为触发速率限制而导致卡片一直处于加载状态或显示无效数据。
- 在 GitHub 不可用或被速率限制时，保留上一次成功获取的仓库元数据，并为尚未缓存的仓库提供可用的降级卡片。

增强功能：
- 扫描 Markdown 和 MDX 内容中引用的仓库并生成排序后的元数据缓存，可选支持仅用于构建阶段的 GitHub Token，并对描述、统计数据、头像和许可证进行静态渲染。

构建：
- 将 GitHub 卡片元数据生成集成到生产构建流程中，并通过专用的包脚本对外提供。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将 GitHub 卡片数据的获取移入构建流程，使仓库卡片变为静态的、更健壮，并且不再依赖访问者端对 GitHub API 的访问。

错误修复：
- 从构建时缓存的元数据中渲染 GitHub 仓库卡片，而不是通过浏览器端的 API 请求，从而防止因为速率限制导致卡片一直处于加载状态或显示无效数值。
- 当 GitHub 不可用或被速率限制时，保留先前缓存的仓库元数据，同时为尚未缓存的仓库提供可用的降级方案。

增强功能：
- 从 Markdown 和 MDX 内容中自动发现被引用的仓库，并静态渲染其描述、统计信息、头像、使用的编程语言和许可证信息。
- 一致地校验仓库引用，并支持仅在构建时使用的可选 GitHub Token，同时不将该 Token 包含在站点输出中。

构建：
- 将 GitHub 卡片缓存的生成加入生产构建流程，并通过专用的包脚本对外暴露。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move GitHub card data retrieval into the build process to make repository cards static, resilient, and independent of visitor-side GitHub API access.

Bug Fixes:
- Render GitHub repository cards from build-time cached metadata instead of browser-side API requests, preventing rate-limit responses from leaving cards stuck loading or displaying invalid values.
- Retain previously cached repository metadata when GitHub is unavailable or rate-limited, while providing a usable fallback for uncached repositories.

Enhancements:
- Discover referenced repositories from Markdown and MDX content and statically render their descriptions, statistics, avatars, languages, and licenses.
- Validate repository references consistently and support an optional build-only GitHub token without including it in site output.

Build:
- Add GitHub card cache generation to the production build and expose it through a dedicated package script.

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将 GitHub 卡片数据的获取移入构建流程，使仓库卡片变为静态的、更健壮，并且不再依赖访问者端对 GitHub API 的访问。

错误修复：
- 从构建时缓存的元数据中渲染 GitHub 仓库卡片，而不是通过浏览器端的 API 请求，从而防止因为速率限制导致卡片一直处于加载状态或显示无效数值。
- 当 GitHub 不可用或被速率限制时，保留先前缓存的仓库元数据，同时为尚未缓存的仓库提供可用的降级方案。

增强功能：
- 从 Markdown 和 MDX 内容中自动发现被引用的仓库，并静态渲染其描述、统计信息、头像、使用的编程语言和许可证信息。
- 一致地校验仓库引用，并支持仅在构建时使用的可选 GitHub Token，同时不将该 Token 包含在站点输出中。

构建：
- 将 GitHub 卡片缓存的生成加入生产构建流程，并通过专用的包脚本对外暴露。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move GitHub card data retrieval into the build process to make repository cards static, resilient, and independent of visitor-side GitHub API access.

Bug Fixes:
- Render GitHub repository cards from build-time cached metadata instead of browser-side API requests, preventing rate-limit responses from leaving cards stuck loading or displaying invalid values.
- Retain previously cached repository metadata when GitHub is unavailable or rate-limited, while providing a usable fallback for uncached repositories.

Enhancements:
- Discover referenced repositories from Markdown and MDX content and statically render their descriptions, statistics, avatars, languages, and licenses.
- Validate repository references consistently and support an optional build-only GitHub token without including it in site output.

Build:
- Add GitHub card cache generation to the production build and expose it through a dedicated package script.

</details>

</details>

</details>