### PR TITLE
fix: 修正 Cloudflare 构建产物路径

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "check": "astro check",
-    "build": "npx tsx scripts/generate-github-card-data.ts && npx tsx scripts/generate-lqips.ts && npx tsx scripts/generate-vndb-covers.ts && astro build && npx tsx scripts/prune-pio-assets.ts && npx tsx scripts/subset-fonts.ts && npx tsx scripts/minify-inline-scripts.ts && pagefind --site dist",
+    "build": "npx tsx scripts/generate-github-card-data.ts && npx tsx scripts/generate-lqips.ts && npx tsx scripts/generate-vndb-covers.ts && astro build && npx tsx scripts/prune-pio-assets.ts && npx tsx scripts/subset-fonts.ts && npx tsx scripts/minify-inline-scripts.ts && npx tsx scripts/run-pagefind.ts",
     "preview": "astro preview",
     "astro": "astro",
     "type-check": "tsc --noEmit --isolatedDeclarations",

--- a/scripts/minify-inline-scripts.ts
+++ b/scripts/minify-inline-scripts.ts
@@ -5,8 +5,10 @@
 import fs from "node:fs/promises";
 import { transformSync } from "esbuild";
 import { glob } from "glob";
+import { resolveSiteRoot } from "./site-root";
 
-const DIST_DIR = "dist";
+// Cloudflare Pages 上产物在 dist/client，本地在 dist，统一对准真实根目录
+const DIST_DIR = resolveSiteRoot();
 
 // <script ...>...</script>，惰性匹配内容，属性里不允许出现 >
 const SCRIPT_RE = /<script([^>]*)>([\s\S]*?)<\/script>/gi;

--- a/scripts/prune-pio-assets.ts
+++ b/scripts/prune-pio-assets.ts
@@ -7,8 +7,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { glob } from "glob";
 import { live2dWidgetConfig, spineModelConfig } from "../src/config";
+import { resolveSiteRoot } from "./site-root";
 
-const DIST_DIR = "dist";
+// Cloudflare Pages 上产物在 dist/client，本地在 dist，统一对准真实根目录
+const DIST_DIR = resolveSiteRoot();
 
 // 看板娘资源根目录（相对 dist/），两种看板娘都关掉时整个删掉
 const PIO_ROOT = "pio";

--- a/scripts/run-pagefind.ts
+++ b/scripts/run-pagefind.ts
@@ -1,0 +1,17 @@
+// 在 astro build 之后运行 Pagefind。
+// 之前直接在 package.json 里写 `pagefind --site dist`，在 Cloudflare Pages（产物在
+// dist/client）上会索引出 /client/... 的假路径，并且索引输出到 dist/pagefind，
+// 根本不会随站点部署 —— 线上搜索一直是 404。这里对准真正的站点根目录再跑，
+// 索引会输出到 <root>/pagefind，随站点一起上传。
+
+import { spawnSync } from "node:child_process";
+import { resolveSiteRoot } from "./site-root";
+
+const siteRoot = resolveSiteRoot();
+
+const result = spawnSync("pagefind", ["--site", siteRoot], {
+	stdio: "inherit",
+	// Windows 下 .bin 里是 .cmd 包装，需要 shell 才能解析到
+	shell: process.platform === "win32",
+});
+process.exit(result.status ?? 1);

--- a/scripts/site-root.ts
+++ b/scripts/site-root.ts
@@ -1,0 +1,11 @@
+import { existsSync } from "node:fs";
+
+/**
+ * 构建产物根目录。
+ *
+ * Cloudflare Pages 上构建时启用了 @astrojs/cloudflare adapter（CF_WORKERS 环境变量），
+ * Astro 把静态站点输出到 dist/client；本地直接跑 astro build 时输出到 dist。
+ */
+export function resolveSiteRoot(): string {
+	return existsSync("dist/client") ? "dist/client" : "dist";
+}

--- a/scripts/subset-fonts.ts
+++ b/scripts/subset-fonts.ts
@@ -9,11 +9,14 @@ import { glob } from "glob";
 import subsetFont from "subset-font";
 import { fontConfig, fontsList } from "../src/config";
 import { collectUsedFontCssVars, toPublicPath } from "../src/utils/fontHelper";
+import { resolveSiteRoot } from "./site-root";
 
 // ─── 配置 ───────────────────────────────────────────────
 
-const DIST_DIR = "dist";
-const OUTPUT_DIR = "dist/_astro/fonts";
+// Cloudflare Pages 上产物在 dist/client，本地在 dist，统一对准真实根目录
+const siteRoot = resolveSiteRoot();
+const DIST_DIR = siteRoot;
+const OUTPUT_DIR = `${siteRoot}/_astro/fonts`;
 
 // ─── 字体配置解析 ────────────────────────────────────────
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

N/A

## Changes

- Add a shared site-root resolver that selects `dist/client` for Cloudflare builds and `dist` for local static builds.
- Update mascot asset pruning, font subsetting, and inline-script minification to operate on the resolved output directory.
- Run Pagefind through a TypeScript wrapper so its index is generated inside the deployed site root instead of producing incorrect `/client/...` paths.

## How To Test

- `pnpm check`
- `pnpm type-check`
- `pnpm exec biome check scripts/site-root.ts scripts/run-pagefind.ts scripts/minify-inline-scripts.ts scripts/prune-pio-assets.ts scripts/subset-fonts.ts`
- `pnpm build`
- Verify that `resolveSiteRoot()` returns `dist/client` when that directory exists.

## Screenshots (if applicable)

N/A — no UI changes.

## Additional Notes

The resolver keeps the existing local `dist` behavior while ensuring Cloudflare post-build processing and Pagefind output target `dist/client`.

## Sourcery 摘要

统一解析本地与 Cloudflare 构建产物根目录，确保构建后资源处理和搜索索引输出到正确的部署目录。

错误修复：
- 修正 Cloudflare 构建后处理和 Pagefind 索引使用错误产物路径的问题，确保搜索索引及相关资源随部署站点正确生成。

增强功能：
- 统一本地构建与 Cloudflare 构建的站点根目录解析，使资源清理、字体子集化和内联脚本压缩处理实际部署目录。

构建：
- 将 Pagefind 构建步骤改为通过脚本使用解析后的站点根目录运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

统一解析本地与 Cloudflare 构建产物根目录，确保构建后资源处理和搜索索引输出到正确的部署目录。

Bug Fixes:
- 修正 Cloudflare 构建后处理和 Pagefind 索引使用错误产物路径的问题，确保搜索索引及相关资源随部署站点正确生成。

Enhancements:
- 统一本地构建与 Cloudflare 构建的站点根目录解析，使资源清理、字体子集化和内联脚本压缩处理实际部署目录。

Build:
- 将 Pagefind 构建步骤改为通过脚本使用解析后的站点根目录运行。

</details>