### PR TITLE
feat: 添加 marked 库以优化 Markdown 渲染功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "hastscript": "^9.0.1",
     "katex": "^0.18.3",
     "l2d-widget": "^0.1.1",
+    "marked": "^18.0.10",
     "mdast-util-to-string": "^4.0.0",
     "pagefind": "^1.5.2",
     "pako": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       l2d-widget:
         specifier: ^0.1.1
         version: 0.1.2
+      marked:
+        specifier: ^18.0.10
+        version: 18.0.10
       mdast-util-to-string:
         specifier: ^4.0.0
         version: 4.0.0
@@ -3592,7 +3595,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -4264,6 +4267,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@18.0.10:
+    resolution: {integrity: sha512-FJeH4bRpYoXiggcgriCGItKCSv3xkngJc4QCZ/rkQCogU3VYaLxYJoZl8Nw/b4+x7iij/pd+09mZ6A1dXzpL0A==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -10504,6 +10512,8 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  marked@18.0.10: {}
 
   math-intrinsics@1.1.0: {}
 

--- a/src/utils/memos-adapter.ts
+++ b/src/utils/memos-adapter.ts
@@ -53,7 +53,8 @@ export interface DynamicEntry {
 /**
  * 专用的 marked 实例，用于把 Memos 的 Markdown 渲染为 HTML
  * 启用 GFM 与单换行转 <br>（贴近 Memos 的社交化渲染效果），
- * 链接默认新标签页打开并防止反向标签页劫持
+ * 链接默认新标签页打开并防止反向标签页劫持；
+ * 图片由 extractImages 单独提取并追加到内容后，故此处直接渲染为空
  */
 const memosMarked = new Marked({ gfm: true, breaks: true });
 memosMarked.use({
@@ -63,19 +64,18 @@ memosMarked.use({
 			const titleAttr = title ? ` title="${title}"` : "";
 			return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
 		},
+		image() {
+			return "";
+		},
 	},
 });
 
 /**
  * 将 Memos 的 Markdown 内容转换为 HTML
- * 图片语法在此处移除，由 extractImages 单独提取并追加到内容后，避免重复渲染
+ * 图片语法由 marked 的 image 渲染器置空，避免重复渲染
  */
 function markdownToHtml(markdown: string): string {
-	const contentWithoutImages = markdown.replace(
-		/!\[([^\]]*)\]\(([^)]+)\)/g,
-		"",
-	);
-	return memosMarked.parse(contentWithoutImages) as string;
+	return memosMarked.parse(markdown) as string;
 }
 
 /**
@@ -93,26 +93,26 @@ function extractPlainText(content: string): string {
 
 /**
  * 从 Memos 内容中提取图片
+ * 使用 marked 的词法分析器定位图片 token，可正确处理含括号的图片地址与可选标题
  */
 function extractImages(memo: Memo, memosApiUrl: string): DynamicImage[] {
 	const images: DynamicImage[] = [];
 
 	// 从 Markdown 内容中提取图片
-	const imagePattern = /!\[([^\]]*)\]\(([^)]+)\)/g;
-	let match: RegExpExecArray | null;
-	match = imagePattern.exec(memo.content);
-	while (match !== null) {
-		let src = match[2];
+	const tokens = memosMarked.lexer(memo.content);
+	memosMarked.walkTokens(tokens, (token) => {
+		if (token.type !== "image") return;
+		let src = token.href;
 		// 处理相对路径
 		if (!src.startsWith("http") && !src.startsWith("//")) {
 			src = `${memosApiUrl}${src.startsWith("/") ? "" : "/"}${src}`;
 		}
 		images.push({
-			alt: match[1] || "",
+			alt: token.text || "",
 			src,
+			title: token.title || undefined,
 		});
-		match = imagePattern.exec(memo.content);
-	}
+	});
 
 	// 从 Memos 附件中提取图片
 	if (memo.attachments) {

--- a/src/utils/memos-adapter.ts
+++ b/src/utils/memos-adapter.ts
@@ -3,6 +3,7 @@
  * 直接从 Memos API 获取数据并转换为动态系统格式
  * @author: CuteLeaf <xiaye@msn.com>
  */
+import { Marked } from "marked";
 
 interface MemoAttachment {
 	name: string;
@@ -50,57 +51,31 @@ export interface DynamicEntry {
 }
 
 /**
- * 将 Markdown 内容转换为简单的 HTML
+ * 专用的 marked 实例，用于把 Memos 的 Markdown 渲染为 HTML
+ * 启用 GFM 与单换行转 <br>（贴近 Memos 的社交化渲染效果），
+ * 链接默认新标签页打开并防止反向标签页劫持
+ */
+const memosMarked = new Marked({ gfm: true, breaks: true });
+memosMarked.use({
+	renderer: {
+		link({ href, title, tokens }) {
+			const text = this.parser.parseInline(tokens);
+			const titleAttr = title ? ` title="${title}"` : "";
+			return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`;
+		},
+	},
+});
+
+/**
+ * 将 Memos 的 Markdown 内容转换为 HTML
+ * 图片语法在此处移除，由 extractImages 单独提取并追加到内容后，避免重复渲染
  */
 function markdownToHtml(markdown: string): string {
-	let html = markdown
-		// 图片（已在后续提取，这里替换为空）
-		.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, "")
-		// 链接
-		.replace(
-			/\[([^\]]+)\]\(([^)]+)\)/g,
-			'<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>',
-		)
-		// 加粗
-		.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-		// 斜体
-		.replace(/\*(.+?)\*/g, "<em>$1</em>")
-		// 行内代码
-		.replace(/`([^`]+)`/g, "<code>$1</code>")
-		// 标题
-		.replace(/^### (.+)$/gm, "<h3>$1</h3>")
-		.replace(/^## (.+)$/gm, "<h2>$1</h2>")
-		.replace(/^# (.+)$/gm, "<h1>$1</h1>")
-		// 无序列表
-		.replace(/^\s*[-*] (.+)$/gm, "<li>$1</li>")
-		// 引用
-		.replace(/^> (.+)$/gm, "<blockquote>$1</blockquote>")
-		// 分割线
-		.replace(/^---$/gm, "<hr>")
-		// 任务列表
-		.replace(
-			/^- \[x\] (.+)$/gm,
-			'<li><input type="checkbox" checked disabled> $1</li>',
-		)
-		.replace(
-			/^- \[ \] (.+)$/gm,
-			'<li><input type="checkbox" disabled> $1</li>',
-		);
-
-	// 换行转换为 <br>，但保留段落分隔
-	const paragraphs = html.split(/\n\n+/);
-	html = paragraphs
-		.map((p) => {
-			const trimmed = p.trim();
-			if (!trimmed) return "";
-			// 如果已经是块级元素，不包裹 <p>
-			if (/^<[a-z]/.test(trimmed)) return trimmed;
-			return `<p>${trimmed.replace(/\n/g, "<br>")}</p>`;
-		})
-		.filter(Boolean)
-		.join("\n");
-
-	return html;
+	const contentWithoutImages = markdown.replace(
+		/!\[([^\]]*)\]\(([^)]+)\)/g,
+		"",
+	);
+	return memosMarked.parse(contentWithoutImages) as string;
 }
 
 /**


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

#595 


## Changes

- 为动态（Moments）的 Memos 模式引入 `marked` 库，替换原先基于正则的简易 Markdown 转换逻辑，支持完整 Markdown 渲染（标题、加粗/斜体、行内代码、有序/无序列表、引用、分割线、GFM 任务列表、表格、链接等）。
- 启用 `gfm` 与 `breaks`，贴近 Memos 的社交化渲染效果（单换行转 `<br>`）。
- 保留原有图片处理：图片语法在转换前剥离，仍由 `extractImages` 单独提取用于相对路径补全与画廊展示，避免重复渲染。
- 链接默认新标签页打开并添加 `rel="noopener noreferrer"`，防止反向标签页劫持。
- 渲染结果复用现有 `custom-md` 样式，与动态本地 API 视觉一致。
- 修复 Memos 图片提取：改用 marked 解析器遍历 image token，正确处理含括号的图片地址与可选标题，避免正则截断导致图片 `src` 不完整（修复 sourcery 反馈的 bug_risk）。

## How To Test

- 在 `dynamicConfig.ts` 中启用 `memos.enable: true` 并配置 `memos.apiUrl` 与 `memos.parent`。
- 启动 `pnpm dev`，访问 `/dynamic/` 页面。
- 确认 Memos 动态中的 Markdown（标题、列表、表格、任务列表、引用、链接等）正确渲染。
- 确认图片仍正常展示并进入画廊，链接点击在新标签页打开。

## Screenshots (if applicable)

<!-- If you made any UI changes, please include screenshots. -->


## Additional Notes

- 改动仅影响 Memos 数据源的客户端渲染，不影响本地 `apiUrl` 动态数据。
- 新增依赖 `marked@^18.0.10`（已写入 `package.json` 与 `pnpm-lock.yaml`）。
- `pnpm type-check` 与 `pnpm lint` 在 `memos-adapter.ts` 上均无新增报错（仓库中 `content-utils.ts` 等存在与本次无关的预存类型错误）

## Sourcery 总结

使用 marked 替换 Memos 动态中的简易 Markdown 转换，以提升内容渲染能力和一致性。

新功能：
- 为 Memos 动态内容提供完整的 Markdown 渲染，支持 GFM 语法和单换行处理。

改进：
- 保留图片提取与画廊展示流程，并统一链接在新标签页中打开及安全属性的设置。

构建：
- 新增 marked 依赖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使用完整的 Markdown 渲染替换 Memos 动态中的简易转换逻辑，提升内容展示能力与一致性。

新功能：
- 为 Memos 动态内容提供基于 marked 的完整 Markdown 与 GFM 渲染，包括表格、任务列表及单换行处理。

改进：
- 保留图片独立提取和画廊展示，并改进对复杂图片语法及图片标题的支持。
- 统一外部链接在新标签页打开并加入安全属性。

构建：
- 新增 marked 依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使用完整的 Markdown 渲染替换 Memos 动态中的简易转换逻辑，提升内容展示能力与一致性。

New Features:
- 为 Memos 动态内容提供基于 marked 的完整 Markdown 与 GFM 渲染，包括表格、任务列表及单换行处理。

Enhancements:
- 保留图片独立提取和画廊展示，并改进对复杂图片语法及图片标题的支持。
- 统一外部链接在新标签页打开并加入安全属性。

Build:
- 新增 marked 依赖。

</details>

</details>