### PR TITLE
fix: improve aria-label for uncategorized posts in PostMeta

### DIFF
--- a/src/components/layout/PostMeta.astro
+++ b/src/components/layout/PostMeta.astro
@@ -124,7 +124,7 @@ const visibleTags =
         <div class="flex flex-row flex-nowrap items-center">
           <a
             href={getCategoryUrl(category || "")}
-            aria-label={`View all posts in the ${category} category`}
+            aria-label={`View all posts in the ${category || i18n(I18nKey.uncategorized)} category`}
             class="link-lg transition text-50 text-sm font-medium
               hover:text-(--primary) dark:hover:text-(--primary) whitespace-nowrap"
           >


### PR DESCRIPTION
## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md)document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

N/A — found during code review of the `PostMeta.astro` component.

## Changes

Fixed an accessibility (a11y) bug in `src/components/layout/PostMeta.astro` where the `aria-label` attribute on the category link displayed `null` or `undefined` when a post had no category assigned.

**Before:**

```astro
aria-label={`View all posts in the ${category} category`}
```

When `category` is `null` or `undefined`, the `aria-label` renders as `View all posts in the null category` or `View all posts in the undefined category`, which is confusing for screen reader users.

**After:**

```astro
aria-label={`View all posts in the ${category || i18n(I18nKey.uncategorized)} category`}
```

This change makes the `aria-label` consistent with the visible text (line 131), which already uses `category || i18n(I18nKey.uncategorized)` to display the localized "Uncategorized" text. The fix reuses the existing `i18n(I18nKey.uncategorized)` translation key — no new translations are needed.

## How To Test

1. Create or use a post without a `category` field in its frontmatter (or set it to `null`).
2. Navigate to the post page.
3. Inspect the category link's `aria-label` attribute using browser DevTools or a screen reader.
4. **Before fix**: `aria-label` reads `View all posts in the null category` (or `undefined`).
5. **After fix**: `aria-label` reads `View all posts in the Uncategorized category` (or the localized equivalent).

## Screenshots (if applicable)

N/A — the change only affects the `aria-label` attribute, not the visual appearance.

## Additional Notes

- This is a single-line change with no functional side effects.
- The fix reuses the existing `i18n(I18nKey.uncategorized)` key, consistent with the visible text rendering in the same component (line 131).
- This change deliberately mirrors the existing `||` fallback already used for the visible text on line 131. The empty-string edge case (`category === ""`) is therefore handled identically for both the visible label and the `aria-label`, so they stay consistent. If `""` should ever be a valid category name, that would be a pre-existing behavior of line 131 and is outside the scope of this fix.
- Passes `biome check`, `biome format`, and `astro check` (`pnpm check`) with no warnings or errors — `astro check` reports 0 errors / 0 warnings / 0 hints across 249 files.

## Sourcery 摘要

错误修复：
- 当文章没有分类时，在分类链接的 ARIA 文本中使用本地化的“未分类”标签，避免屏幕阅读器用户听到 null 或 undefined 的提示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Use the localized “Uncategorized” label in category link ARIA text when posts have no category, avoiding null or undefined announcements for screen reader users.

</details>