### PR TITLE
fix: improve category bar wheel scrolling

### DIFF
--- a/src/components/layout/CategoryBar.astro
+++ b/src/components/layout/CategoryBar.astro
@@ -161,7 +161,6 @@ function initialActive(categoryName: string): {
   .category-scroll {
     scrollbar-width: none;
     -ms-overflow-style: none;
-    scroll-behavior: smooth;
   }
   .category-scroll::-webkit-scrollbar {
     display: none;
@@ -340,11 +339,34 @@ function initialActive(categoryName: string): {
     }
     scroll.dataset.featuresBound = "true";
 
-    // 鼠标滚轮横向滚动
+    // 将垂直滚轮映射为即时横向滚动；触控板的原生水平滚动交给浏览器处理
     scroll.addEventListener("wheel", (e) => {
-      if (scroll.scrollWidth <= scroll.clientWidth) return;
+      if (
+        scroll.scrollWidth <= scroll.clientWidth ||
+        e.ctrlKey ||
+        Math.abs(e.deltaX) >= Math.abs(e.deltaY)
+      ) return;
+
+      const delta = e.deltaMode === WheelEvent.DOM_DELTA_LINE
+        ? e.deltaY * 16
+        : e.deltaMode === WheelEvent.DOM_DELTA_PAGE
+          ? e.deltaY * scroll.clientWidth
+          : e.deltaY;
+      const maxScrollLeft = scroll.scrollWidth - scroll.clientWidth;
+      const atStart = scroll.scrollLeft <= 1;
+      const atEnd = scroll.scrollLeft >= maxScrollLeft - 1;
+
+      // 到达边界后允许页面继续垂直滚动
+      if ((delta < 0 && atStart) || (delta > 0 && atEnd)) return;
+
+      const nextScrollLeft = Math.min(
+        maxScrollLeft,
+        Math.max(0, scroll.scrollLeft + delta),
+      );
+
+      if (nextScrollLeft === scroll.scrollLeft) return;
       e.preventDefault();
-      scroll.scrollLeft += e.deltaY;
+      scroll.scrollLeft = nextScrollLeft;
     }, { passive: false });
 
     // 监听滚动更新提示图标


### PR DESCRIPTION
## Summary

Fix the category bar's wheel scrolling so vertical wheel input responds immediately, horizontal trackpad gestures keep their native behavior, and page scrolling resumes at the ends of the category list.

## Problem

The horizontally scrollable category list did not respond naturally to common wheel and trackpad input:

- Vertical mouse-wheel scrolling felt delayed and dropped part of the accumulated movement during rapid input.
- Native horizontal trackpad gestures produced no movement.
- At the horizontal boundaries, the category list could keep consuming vertical wheel input instead of allowing the page to scroll, especially when the layout produced a fractional maximum `scrollLeft`.

In browser reproduction before the fix, a single 120 px vertical wheel input remained at 0 immediately after the event, reached only 1 px after 16 ms, and took roughly 240 ms to reach 120 px. Eight consecutive 20 px inputs requested 160 px of movement but stopped at approximately 107 px. A horizontal-only trackpad gesture left `scrollLeft` unchanged.

## Root Cause

The category scroll container applied `scroll-behavior: smooth` globally while its wheel handler assigned `scrollLeft += deltaY` for every event. Each assignment therefore retargeted an in-progress smooth-scroll animation from an intermediate position, introducing latency and discarding part of rapid accumulated input.

The same handler also called `preventDefault()` for every overflowing wheel event but only consumed `deltaY`. This suppressed the browser's native `deltaX` handling without applying any horizontal movement itself. Finally, its exact boundary comparison did not account for fractional layout values, so a browser-reported position such as 68.5 px could remain just below a calculated 69 px maximum and continue trapping page scroll.

## Changes

- Remove the container-wide `scroll-behavior: smooth` rule that caused repeated wheel updates to retarget an in-progress animation and lose scroll distance.
- Keep smooth scrolling for active-category positioning through its existing explicit `scrollTo({ behavior: "smooth" })` call.
- Convert only dominant vertical wheel input into horizontal movement while leaving horizontal gestures and Ctrl+wheel gestures to the browser.
- Normalize line- and page-based wheel deltas, clamp the target position, and use a 1 px boundary tolerance for fractional layouts.
- Stop preventing the default wheel action once the category list reaches either end so the page can continue scrolling.

## Validation

- `pnpm check`
- `pnpm type-check`
- `pnpm build`
- Browser-tested vertical wheel scrolling: each input was applied immediately and eight 20 px inputs preserved the full 160 px distance.
- Browser-tested native horizontal trackpad scrolling.
- Browser-tested page-scroll pass-through at both category-list boundaries, including a 390 px viewport with a fractional maximum `scrollLeft`.
- Browser-tested that active-category smooth positioning still works after navigation.

## Screenshots

Not applicable. This changes input behavior without changing the rendered appearance.

## Sourcery 摘要

改进分类栏滚轮处理，以支持响应式垂直滚动、原生水平手势和边界穿透。

Bug 修复：
- 修复分类栏滚轮滚动问题，使垂直输入能够立即应用，同时不会丢失累积的移动量。
- 当分类列表位于任一水平边界时，允许页面滚动穿透。

增强功能：
- 保留原生水平触控板手势和 Ctrl+滚轮行为，同时将占主导的垂直滚轮输入映射为水平滚动。
- 保留活动分类定位时的平滑滚动，同时移除容器范围的平滑滚动行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve category bar wheel handling for responsive vertical scrolling, native horizontal gestures, and boundary pass-through.

Bug Fixes:
- Fix category bar wheel scrolling so vertical input is applied immediately without losing accumulated movement.
- Allow page scrolling to pass through when the category list is at either horizontal boundary.

Enhancements:
- Preserve native horizontal trackpad and Ctrl+wheel behavior while mapping dominant vertical wheel input to horizontal scrolling.
- Retain smooth scrolling for active-category positioning while removing the container-wide smooth-scroll behavior.

</details>
