### PR TITLE
feat: 打赏页面的收款方式支持markdown

### DIFF
--- a/src/pages/sponsor.astro
+++ b/src/pages/sponsor.astro
@@ -1,6 +1,9 @@
 ---
 import Comment from "@components/comment/index.astro";
+import Markdown from "@components/common/Markdown.astro";
 import { Icon } from "astro-icon/components";
+import { Marked } from "marked";
+import sanitizeHtml from "sanitize-html";
 import { commentConfig, siteConfig, sponsorConfig } from "@/config";
 import I18nKey from "@/i18n/i18nKey";
 import { i18n } from "@/i18n/translation";
@@ -22,7 +25,35 @@ const isCommentEnabled =
 const title = sponsorConfig.title || i18n(I18nKey.sponsorTitle);
 const description =
 	sponsorConfig.description || i18n(I18nKey.sponsorDescription);
-const enabledMethods = sponsorConfig.methods.filter((method) => method.enabled);
+const markdown = new Marked({ gfm: true });
+const descriptionFiles = import.meta.glob<string>(
+	"/src/content/sponsor/**/*.md",
+	{
+		query: "?raw",
+		import: "default",
+		eager: true,
+	},
+);
+const enabledMethods = sponsorConfig.methods
+	.filter((method) => method.enabled)
+	.map((method) => {
+		const source = method.descriptionFile
+			? descriptionFiles[`/src/content/sponsor/${method.descriptionFile}`]
+			: method.description;
+		if (method.descriptionFile && source === undefined) {
+			throw new Error(
+				`Sponsor description file not found: ${method.descriptionFile}`,
+			);
+		}
+		return {
+			...method,
+			descriptionHtml: source
+				? sanitizeHtml(markdown.parse(source, { async: false }), {
+						allowedTags: sanitizeHtml.defaults.allowedTags.concat(["img"]),
+					})
+				: "",
+		};
+	});
 const sponsors = sponsorConfig.sponsors || [];
 const showSponsorsList = sponsorConfig.showSponsorsList !== false;
 
@@ -67,7 +98,7 @@ function getQrLqipProps(qrCode: string) {
       <div class="mb-8">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
                     {enabledMethods.map((method) => (
-                      <div class="flex flex-col items-center card-base p-6 rounded-lg bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 hover:border-(--primary) transition-colors">
+                      <div class="flex flex-col items-center min-w-0 card-base p-6 rounded-lg bg-neutral-50 dark:bg-neutral-900/50 border border-neutral-200 dark:border-neutral-800 hover:border-(--primary) transition-colors">
                         <!-- 图标和名称 -->
                         <div class="flex items-center gap-3 mb-4">
                           {method.icon && (
@@ -79,10 +110,10 @@ function getQrLqipProps(qrCode: string) {
                         </div>
 
                         <!-- 描述 -->
-                        {method.description && (
-                          <p class="text-sm text-neutral-600 dark:text-neutral-400 mb-4 text-center">
-                            {method.description}
-                          </p>
+                        {method.descriptionHtml && (
+                          <Markdown class="sponsor-description w-full min-w-0 mb-4 text-left text-sm! text-neutral-600 dark:text-neutral-400">
+                            <Fragment set:html={method.descriptionHtml} />
+                          </Markdown>
                         )}
 
                         <!-- 二维码或链接 -->
@@ -196,6 +227,18 @@ function getQrLqipProps(qrCode: string) {
 </MainGridLayout>
 
 <style>
+  :global(.sponsor-description) {
+    overflow-wrap: anywhere;
+  }
+
+  :global(.sponsor-description > :first-child) {
+    margin-top: 0;
+  }
+
+  :global(.sponsor-description > :last-child) {
+    margin-bottom: 0;
+  }
+
   /* 透明模式下使用半透明背景 */
   :global(body.wallpaper-transparent .usage-info-box) {
     background-color: rgba(var(--primary-rgb, 70, 130, 180), 0.15) !important;
@@ -213,4 +256,3 @@ function getQrLqipProps(qrCode: string) {
     gap: 0.75rem;
   }
 </style>
-

--- a/src/types/sponsorConfig.ts
+++ b/src/types/sponsorConfig.ts
@@ -4,7 +4,8 @@ export type SponsorMethod = {
 	icon?: string; // 图标名称（Iconify 格式），如 "fa7-brands:alipay"
 	qrCode?: string; // 收款码图片路径（相对于 public 目录），可选
 	link?: string; // 打赏链接 URL，可选。如果提供，会显示跳转按钮
-	description?: string; // 描述文本
+	description?: string; // 支持 Markdown，可使用反引号包裹多行字符串
+	descriptionFile?: string; // Markdown 文件路径，相对于 src/content/sponsor；优先于 description
 	enabled: boolean; // 是否启用
 };
 


### PR DESCRIPTION
每个收款方式的描述都支持 Markdown，有两种写法：
- 直接写在 TS 的 description 中：用反引号包住多行 Markdown。
- 使用独立 .md 文件：放在 src/content/sponsor/ 下，再设置 descriptionFile: "文件名.md"。

两者同时设置时，优先使用 descriptionFile。

## Sourcery 摘要

为赞助商付款方式启用丰富的 Markdown 描述，包括可复用的外部内容文件。

新功能：
- 支持从内联配置或 `src/content/sponsor/` 下的专用文件中为赞助商付款方式添加 Markdown 描述，文件中的描述优先级更高。

增强功能：
- 在赞助商付款方式卡片中渲染经过清理的 Markdown 描述，并改进换行和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable rich Markdown descriptions for sponsor payment methods, including reusable external content files.

New Features:
- Add Markdown support for sponsor payment method descriptions from inline configuration or dedicated files under src/content/sponsor/, with file descriptions taking precedence.

Enhancements:
- Render sanitized Markdown descriptions with improved wrapping and layout within sponsor method cards.

</details>