### PR TITLE
fix: 修复评论区表情面板被裁剪及分类切换抖动

### DIFF
--- a/src/components/comment/Waline.astro
+++ b/src/components/comment/Waline.astro
@@ -31,3 +31,22 @@ const config = {
     }
   </script>
 </div>
+
+<style is:global>
+  /* 各分类表情数量不同，切换时面板布局会跟着变，下面逐项消除 */
+
+  .wl-tab-wrapper {
+    /* 内容溢出时出现的滚动条会挤掉约 6px 宽度，网格随之重排 */
+    scrollbar-gutter: stable;
+    /* 内容不足时网格区按内容收缩，比顶满时矮 1px；固定高度使其恒定。
+       145px 取自 Waline 自身的 max-height，其大版本若调整需同步 */
+    height: 145px;
+  }
+
+  /* Waline 给选中态加了 0 1px 1px 边框，激活的 tab 比未激活宽 2px、高 1px，
+     切换时相邻 tab 会左右挪；给未选中的补等宽透明边框统一占位 */
+  .wl-tabs .wl-tab:not(.active) {
+    border: solid transparent;
+    border-width: 0 1px 1px;
+  }
+</style>

--- a/src/components/comment/index.astro
+++ b/src/components/comment/index.astro
@@ -37,14 +37,16 @@ let commentService: string = commentConfig?.type || "none";
 
 {
   commentService !== "none" && (
-    <div id="post-comments" class="card-base p-8 mb-6 relative overflow-hidden">
-      <!-- 评论区装饰性背景 -->
-      <div class="absolute top-0 right-0 w-32 h-32 opacity-5 pointer-events-none">
-        <svg viewBox="0 0 100 100" class="w-full h-full">
-          <circle cx="50" cy="50" r="40" fill="currentColor" class="text-(--primary)" />
-          <circle cx="50" cy="50" r="25" fill="none" stroke="currentColor" stroke-width="2" class="text-(--primary)" />
-          <circle cx="50" cy="50" r="10" fill="currentColor" class="text-(--primary)" />
-        </svg>
+    <div id="post-comments" class="card-base p-8 mb-6 relative overflow-x-clip overflow-y-visible">
+      <!-- 装饰性背景（单独裁剪层，卡片本体放开纵向 overflow 以免裁掉评论区浮层） -->
+      <div class="absolute inset-0 overflow-hidden rounded-(--radius-large) pointer-events-none">
+        <div class="absolute top-0 right-0 w-32 h-32 opacity-5">
+          <svg viewBox="0 0 100 100" class="w-full h-full">
+            <circle cx="50" cy="50" r="40" fill="currentColor" class="text-(--primary)" />
+            <circle cx="50" cy="50" r="25" fill="none" stroke="currentColor" stroke-width="2" class="text-(--primary)" />
+            <circle cx="50" cy="50" r="10" fill="currentColor" class="text-(--primary)" />
+          </svg>
+        </div>
       </div>
       <!-- 评论区标题 -->
       <div class="relative z-10 mb-6">

--- a/src/utils/sidebar-effective-utils.ts
+++ b/src/utils/sidebar-effective-utils.ts
@@ -55,7 +55,9 @@ export function getEffectiveSidebarState(
 		hasRightComponents: sidebarConfig.hasRightComponents,
 		// 定位类已由 #main-grid 的列几何接管，这里只剩与列位置无关的公共类
 		sidebarClass: "mb-4 onload-animation",
-		staticBarClass: "min-w-0 overflow-hidden",
+		// 只裁横向、纵向放开：评论区浮层（如 Waline 表情面板）需能溢出内容列；
+		// clip 不产生滚动容器，不影响列内吸顶。
+		staticBarClass: "min-w-0 overflow-x-clip overflow-y-visible",
 		gridColumnStyle: gridColumnVarsToStyle(gridColumnVars),
 		gridDataAttrs: {
 			"data-sidebar-enable": sidebarLayoutConfig.enable ? "true" : "false",


### PR DESCRIPTION
# PR：修复评论区表情面板被裁剪及分类切换抖动

涉及 3 个文件：
- `src/components/comment/index.astro`
- `src/components/comment/Waline.astro`
- `src/utils/sidebar-effective-utils.ts`

---

## Type of change

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/CuteLeaf/Firefly/blob/master/CONTRIBUTING.md) document.
- [x] I have checked to ensure that this Pull Request is not for personal changes.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Related Issue

本修复暂无直接关联 issue

## Changes

修复 Waline 回复编辑器内表情面板被主题自身 `overflow:hidden` 纵向裁切、以及切换分类时表情网格与分类 tab 发生位移的问题。

涉及 3 个文件：

### 1. `src/components/comment/index.astro`

评论卡片 `#post-comments` 由 `overflow-hidden` 改为 `overflow-x-clip overflow-y-visible`：只裁横向溢出、纵向放开，表情面板浮层不再被裁。原本靠 `overflow-hidden` 实现的右上角装饰圆裁切，移入独立的绝对定位裁剪层（`.absolute.inset-0.overflow-hidden.rounded-(--radius-large).pointer-events-none`），圆角裁剪效果保留、且不影响评论区浮层。

### 2. `src/utils/sidebar-effective-utils.ts`

内容列 `staticBarClass` 由 `min-w-0 overflow-hidden` 改为 `min-w-0 overflow-x-clip overflow-y-visible`。`overflow-x: clip` 不生成滚动容器、不影响列内元素吸顶，纵向放开后浮层可完整显示。

> 说明：新架构下页脚已移除 `onload-animation`、不再自成堆叠上下文，故无需像旧架构那样给内容列加 `relative z-20`。

### 3. `src/components/comment/Waline.astro`

针对 Waline 表情面板新增全局样式，逐项消除切换分类时的位移：

- `.wl-tab-wrapper` 加 `scrollbar-gutter: stable` —— 预留滚动条槽位，避免内容溢出时的滚动条挤掉约 6px 宽度导致网格重排；
- `.wl-tab-wrapper` 固定 `height: 145px`（取自 Waline 自身 `max-height`）—— 内容不足的分类网格区不再按内容收缩、避免比顶满时矮 1px；
- `.wl-tabs .wl-tab:not(.active)` 补 `border: solid transparent; border-width: 0 1px 1px` —— Waline 给选中态加了 `0 1px 1px` 边框使激活 tab 比未激活宽 2px 高 1px，未选中态补等宽透明边框统一占位，切换时相邻 tab 不再左右挪动。

## How To Test

1. 打开任意启用 Waline 的文章页（需配置 `commentConfig.type: "waline"` 与 `serverURL`）。
2. 点击某条评论的「回复」，进入回评编辑态。
3. 点击工具栏的表情按钮打开面板 → 面板下半截与底部分类 tab 应完整可见、不被裁切。
4. 依次点击不同分类 tab → 表情网格与分类 tab 位置恒定、无位移；点击表情可正常插入（如 `:bb_doge:`）。
5. 验证类型与格式：`npx astro sync && npx tsc --noEmit -p tsconfig.json` 无错误，`npx biome check` 无修复项。

## Screenshots (if applicable)
修复前
![修复前](https://x1anyu.cn/file/NBGTB3wQ.png)
修复后
![修复后](https://x1anyu.cn/file/LfAYSSni.png)
## Additional Notes

无

## Sourcery 总结

修复 Waline 表情选择器的可见性问题，并防止切换表情分类时发生布局偏移。

Bug 修复：
- 防止 Waline 的表情选择器因评论卡片和内容列的溢出设置而在垂直方向被裁剪。
- 消除切换 Waline 表情分类时的布局偏移。

增强功能：
- 独立保留评论卡片的装饰性裁剪，同时允许垂直溢出的评论覆盖层保持可见。
- 通过预留滚动条空间、保持一致的网格高度以及统一标签页尺寸，稳定不同分类下的表情选择器布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Waline emoji picker visibility and prevent layout shifts when switching emoji categories.

Bug Fixes:
- Prevent Waline’s emoji picker from being vertically clipped by the comment card and content column overflow settings.
- Eliminate layout shifts when switching Waline emoji categories.

Enhancements:
- Preserve comment-card decorative clipping independently while allowing vertically overflowing comment overlays to remain visible.
- Stabilize the emoji picker layout across categories by reserving scrollbar space, maintaining a consistent grid height, and equalizing tab dimensions.

</details>

<details>
<summary>Original summary in English</summary>



</details>